### PR TITLE
Added support for aws profiles and unit tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,22 +17,34 @@ class ServerlessCustomDomain {
       create_domain: {
         usage: 'Creates a domain using the domain name defined in the serverless file',
         lifecycleEvents: [
+          'initalize',
           'create',
         ],
       },
       delete_domain: {
         usage: 'Deletes a domain using the domain name defined in the serverless file',
         lifecycleEvents: [
+          'initalize',
           'delete',
         ],
       },
     };
 
     this.hooks = {
+      'delete_domain:initalize': this.initalizeVariables.bind(this),
       'delete_domain:delete': this.deleteDomain.bind(this),
+      'create_domain:initalize': this.initalizeVariables.bind(this),
       'create_domain:create': this.createDomain.bind(this),
+      'before:deploy:initalize': this.initalizeVariables.bind(this),
       'before:deploy:deploy': this.setUpBasePathMapping.bind(this),
     };
+  }
+
+  initalizeVariables() {
+    const awsCreds = this.serverless.providers.aws.getCredentials();
+    this.apigateway = new AWS.APIGateway({ credentials: awsCreds });
+    this.route53 = new AWS.Route53({ credentials: awsCreds });
+    this.givenDomainName = this.serverless.service.custom.customDomain.domainName;
   }
 
   createDomain() {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ class ServerlessCustomDomain {
 
   constructor(serverless) {
     this.serverless = serverless;
+    const awsCreds = this.serverless.providers.aws.getCredentials();
+
+    AWS.config.update(awsCreds);
     this.apigateway = new AWS.APIGateway({
       region: this.serverless.service.provider.region,
     });

--- a/index.js
+++ b/index.js
@@ -9,12 +9,8 @@ class ServerlessCustomDomain {
     const awsCreds = this.serverless.providers.aws.getCredentials();
 
     AWS.config.update(awsCreds);
-    this.apigateway = new AWS.APIGateway({
-      region: this.serverless.service.provider.region,
-    });
-    this.route53 = new AWS.Route53({
-      region: this.serverless.service.provider.region,
-    });
+    this.apigateway = new AWS.APIGateway();
+    this.route53 = new AWS.Route53();
 
 
     this.commands = {

--- a/index.js
+++ b/index.js
@@ -6,12 +6,6 @@ class ServerlessCustomDomain {
 
   constructor(serverless) {
     this.serverless = serverless;
-    const awsCreds = this.serverless.providers.aws.getCredentials();
-
-    AWS.config.update(awsCreds);
-    this.apigateway = new AWS.APIGateway();
-    this.route53 = new AWS.Route53();
-
 
     this.commands = {
       create_domain: {
@@ -31,36 +25,36 @@ class ServerlessCustomDomain {
     };
 
     this.hooks = {
-      'delete_domain:initalize': this.initalizeVariables.bind(this),
+      'delete_domain:initialize': this.initalizeVariables.bind(this),
       'delete_domain:delete': this.deleteDomain.bind(this),
-      'create_domain:initalize': this.initalizeVariables.bind(this),
+      'create_domain:initialize': this.initalizeVariables.bind(this),
       'create_domain:create': this.createDomain.bind(this),
-      'before:deploy:initalize': this.initalizeVariables.bind(this),
+      'before:deploy:initialize': this.initalizeVariables.bind(this),
       'before:deploy:deploy': this.setUpBasePathMapping.bind(this),
     };
   }
 
   initalizeVariables() {
+    // Sets the credentials for AWS resources.
     const awsCreds = this.serverless.providers.aws.getCredentials();
-    this.apigateway = new AWS.APIGateway({ credentials: awsCreds });
-    this.route53 = new AWS.Route53({ credentials: awsCreds });
+    AWS.config.update(awsCreds);
+    this.apigateway = new AWS.APIGateway();
+    this.route53 = new AWS.Route53();
     this.givenDomainName = this.serverless.service.custom.customDomain.domainName;
   }
 
   createDomain() {
-    const givenDomainName = this.serverless.service.custom.customDomain.domainName;
     const createDomainName = this.getCertArn().then(data => this.createDomainName(data));
     const getHosedZoneId = this.getHostedZoneId();
     return Promise.all([createDomainName, getHosedZoneId])
       .then(values => this.changeResourceRecordSet(values[0], 'CREATE', values[1]))
       .then(() => (this.serverless.cli.log('Domain was created, may take up to 40 mins to be initialized.')))
       .catch((err) => {
-        throw new Error(`${err} ${givenDomainName} was not created.`);
+        throw new Error(`${err} ${this.givenDomainName} was not created.`);
       });
   }
 
   deleteDomain() {
-    const givenDomainName = this.serverless.service.custom.customDomain.domainName;
     return this.getDomain().then((data) => {
       const promises = [
         this.changeResourceRecordSet(data.distributionDomainName, 'DELETE'),
@@ -69,7 +63,7 @@ class ServerlessCustomDomain {
 
       return (Promise.all(promises).then(() => (this.serverless.cli.log('Domain was deleted.'))));
     }).catch((err) => {
-      throw new Error(`${err} ${givenDomainName} was not deleted.`);
+      throw new Error(`${err} ${this.givenDomainName} was not deleted.`);
     });
   }
 
@@ -106,7 +100,6 @@ class ServerlessCustomDomain {
    */
   addResources(deployId) {
     const service = this.serverless.service;
-    const givenDomainName = this.serverless.service.custom.customDomain.domainName;
 
     if (!service.custom.customDomain) {
       throw new Error('customDomain settings in Serverless are not configured correctly');
@@ -125,7 +118,7 @@ class ServerlessCustomDomain {
       DependsOn: deployId,
       Properties: {
         BasePath: basePath,
-        DomainName: givenDomainName,
+        DomainName: this.givenDomainName,
         RestApiId: {
           Ref: 'ApiGatewayRestApi',
         },
@@ -155,7 +148,6 @@ class ServerlessCustomDomain {
     });       // us-east-1 is the only region that can be accepted (3/21)
 
     const certArn = acm.listCertificates().promise();
-    const givenDomainName = this.serverless.service.custom.customDomain.domainName;
 
     return certArn.then((data) => {
       // The more specific name will be the longest
@@ -175,7 +167,7 @@ class ServerlessCustomDomain {
           certificateArn = foundCertificate.CertificateArn;
         }
       } else {
-        certificateName = givenDomainName;
+        certificateName = this.givenDomainName;
         data.CertificateSummaryList.forEach((certificate) => {
           let certificateListName = certificate.DomainName;
 
@@ -206,9 +198,8 @@ class ServerlessCustomDomain {
    *  @param certificateArn   The certificate needed to create the new domain
    */
   createDomainName(givenCertificateArn) {
-    const givenDomainName = this.serverless.service.custom.customDomain.domainName;
     const createDomainNameParams = {
-      domainName: givenDomainName,
+      domainName: this.givenDomainName,
       certificateArn: givenCertificateArn,
     };
 
@@ -222,14 +213,13 @@ class ServerlessCustomDomain {
    */
   getHostedZoneId() {
     const hostedZonePromise = this.route53.listHostedZones({}).promise();
-    const givenDomainName = this.serverless.service.custom.customDomain.domainName;
 
     return hostedZonePromise.then((data) => {
       // Gets the hostzone that contains the root of the custom domain name
       let hostedZoneId = data.HostedZones.find((hostedZone) => {
         let hZoneName = hostedZone.Name;
         hZoneName = hZoneName.substr(0, hostedZone.Name.length - 1);   // Takes out the . at the end
-        return givenDomainName.includes(hZoneName);
+        return this.givenDomainName.includes(hZoneName);
       });
       hostedZoneId = hostedZoneId.Id;
       // Extracts the hostzone Id
@@ -248,7 +238,6 @@ class ServerlessCustomDomain {
    *                  The CNAME is specified in the serverless file under domainName
    */
   changeResourceRecordSet(distributionDomainName, action) {
-    const givenDomainName = this.serverless.service.custom.customDomain.domainName;
     if (action !== 'DELETE' && action !== 'CREATE') {
       throw new Error(`${action} is not a valid action. action must be either CREATE or DELETE`);
     }
@@ -260,7 +249,7 @@ class ServerlessCustomDomain {
             {
               Action: action,
               ResourceRecordSet: {
-                Name: givenDomainName,
+                Name: this.givenDomainName,
                 ResourceRecords: [
                   {
                     Value: distributionDomainName,
@@ -279,9 +268,9 @@ class ServerlessCustomDomain {
       return this.route53.changeResourceRecordSets(params).promise();
     }, () => {
       if (action === 'CREATE') {
-        throw new Error(`Record set for ${givenDomainName} already exists.`);
+        throw new Error(`Record set for ${this.givenDomainName} already exists.`);
       }
-      throw new Error(`Record set for ${givenDomainName} does not exist and cannot be deleted.`);
+      throw new Error(`Record set for ${this.givenDomainName} does not exist and cannot be deleted.`);
     });
   }
 
@@ -289,9 +278,8 @@ class ServerlessCustomDomain {
    * Deletes the domain names specified in the serverless file
    */
   clearDomainName() {
-    const givenDomainName = this.serverless.service.custom.customDomain.domainName;
     return this.apigateway.deleteDomainName({
-      domainName: givenDomainName,
+      domainName: this.givenDomainName,
     }).promise();
   }
 
@@ -299,14 +287,13 @@ class ServerlessCustomDomain {
    * Get information on domain
    */
   getDomain() {
-    const givenDomainName = this.serverless.service.custom.customDomain.domainName;
     const getDomainNameParams = {
-      domainName: givenDomainName,
+      domainName: this.givenDomainName,
     };
 
     const getDomainPromise = this.apigateway.getDomainName(getDomainNameParams).promise();
     return getDomainPromise.then(data => (data), () => {
-      throw new Error(`Cannot find specified domain name ${givenDomainName}.`);
+      throw new Error(`Cannot find specified domain name ${this.givenDomainName}.`);
     });
   }
 }

--- a/index.js
+++ b/index.js
@@ -25,16 +25,16 @@ class ServerlessCustomDomain {
     };
 
     this.hooks = {
-      'delete_domain:initialize': this.initalizeVariables.bind(this),
+      'delete_domain:initialize': this.initializeVariables.bind(this),
       'delete_domain:delete': this.deleteDomain.bind(this),
-      'create_domain:initialize': this.initalizeVariables.bind(this),
+      'create_domain:initialize': this.initializeVariables.bind(this),
       'create_domain:create': this.createDomain.bind(this),
-      'before:deploy:initialize': this.initalizeVariables.bind(this),
+      'before:deploy:initialize': this.initializeVariables.bind(this),
       'before:deploy:deploy': this.setUpBasePathMapping.bind(this),
     };
   }
 
-  initalizeVariables() {
+  initializeVariables() {
     // Sets the credentials for AWS resources.
     const awsCreds = this.serverless.providers.aws.getCredentials();
     AWS.config.update(awsCreds);

--- a/index.js
+++ b/index.js
@@ -11,14 +11,14 @@ class ServerlessCustomDomain {
       create_domain: {
         usage: 'Creates a domain using the domain name defined in the serverless file',
         lifecycleEvents: [
-          'initalize',
+          'initialize',
           'create',
         ],
       },
       delete_domain: {
         usage: 'Deletes a domain using the domain name defined in the serverless file',
         lifecycleEvents: [
-          'initalize',
+          'initialize',
           'delete',
         ],
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "engines": {
     "node": ">=4.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -79,6 +79,7 @@ const constructPluginWithoutCertName = (basepath) => {
 describe('Custom Domain Plugin', () => {
   it('check aws config', () => {
     const plugin = constructPlugin({}, 'tests');
+    plugin.initializeVariables();
     const returnedCreds = plugin.apigateway.config.credentials;
     expect(returnedCreds.accessKeyId).to.equal(testCreds.accessKeyId);
     expect(returnedCreds.sessionToken).to.equal(testCreds.sessionToken);
@@ -112,6 +113,8 @@ describe('Custom Domain Plugin', () => {
       AWS.mock('ACM', 'listCertificates', certTestData);
 
       const plugin = constructPluginWithoutCertName('');
+      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
+
 
       const result = await plugin.getCertArn();
 
@@ -134,6 +137,9 @@ describe('Custom Domain Plugin', () => {
       });
 
       const plugin = constructPlugin();
+      plugin.apigateway = new aws.APIGateway();
+      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
+
 
       const result = await plugin.createDomainName('fake_cert');
 
@@ -150,6 +156,9 @@ describe('Custom Domain Plugin', () => {
       });
 
       const plugin = constructPlugin('test_basepath');
+      plugin.route53 = new aws.Route53();
+      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
+
 
       const result = await plugin.changeResourceRecordSet('test_distribution_name', 'CREATE');
       const changes = result.ChangeBatch.Changes[0];
@@ -170,6 +179,8 @@ describe('Custom Domain Plugin', () => {
       });
 
       const plugin = constructPlugin('test_basepath');
+      plugin.apigateway = new aws.APIGateway();
+      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
 
       const result = await plugin.getDomain();
 
@@ -185,6 +196,8 @@ describe('Custom Domain Plugin', () => {
       });
 
       const plugin = constructPlugin('test_basepath');
+      plugin.route53 = new aws.Route53();
+      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
 
       const result = await plugin.changeResourceRecordSet('test_distribution_name', 'DELETE');
       const changes = result.ChangeBatch.Changes[0];
@@ -199,6 +212,9 @@ describe('Custom Domain Plugin', () => {
       });
 
       const plugin = constructPlugin('test_basepath');
+      plugin.apigateway = new aws.APIGateway();
+      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
+
       const result = await plugin.clearDomainName();
       expect(result).to.eql({});
     });
@@ -214,6 +230,8 @@ describe('Custom Domain Plugin', () => {
         callback(null, params);
       });
       const plugin = constructPlugin('');
+      plugin.apigateway = new aws.APIGateway();
+      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
 
       await plugin.setUpBasePathMapping();
       const cfTemplat = plugin.serverless.service.provider.compiledCloudFormationTemplate.Resources;
@@ -234,6 +252,9 @@ describe('Custom Domain Plugin', () => {
         callback(null, params);
       });
       const plugin = constructPlugin();
+      plugin.apigateway = new aws.APIGateway();
+      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
+      plugin.route53 = new aws.Route53();
       const results = await plugin.deleteDomain();
       expect(results).to.equal('Domain was deleted.');
     });
@@ -251,6 +272,9 @@ describe('Custom Domain Plugin', () => {
       });
 
       const plugin = constructPluginWithoutCertName('');
+      plugin.apigateway = new aws.APIGateway();
+      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
+      plugin.route53 = new aws.Route53();
       const result = await plugin.createDomain();
       expect(result).to.equal('Domain was created, may take up to 40 mins to be initialized.');
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -80,7 +80,6 @@ describe('Custom Domain Plugin', () => {
   it('check aws config', () => {
     const plugin = constructPlugin({}, 'tests');
     const returnedCreds = plugin.apigateway.config.credentials;
-    console.log(returnedCreds)
     expect(returnedCreds.accessKeyId).to.equal(testCreds.accessKeyId);
     expect(returnedCreds.sessionToken).to.equal(testCreds.sessionToken);
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,14 +2,25 @@
 
 const chai = require('chai');
 const AWS = require('aws-sdk-mock');
+const aws = require('aws-sdk');
 const certTestData = require('./test-cert-data.json');
 const ServerlessCustomDomain = require('../index.js');
 
 const expect = chai.expect;
 
+const testCreds = {
+  accessKeyId: 'test_key',
+  secretAccessKey: 'test_secret',
+  sessionToken: 'test_session',
+};
 const constructPlugin = (basepath, certName) => {
   const serverless = {
     cli: { log(params) { return params; } },
+    providers: {
+      aws: {
+        getCredentials: () => new aws.Credentials(testCreds),
+      },
+    },
     service: {
       provider: {
         region: 'us-moon-1',
@@ -37,6 +48,11 @@ const constructPlugin = (basepath, certName) => {
 const constructPluginWithoutCertName = (basepath) => {
   const serverless = {
     cli: { log(params) { return params; } },
+    providers: {
+      aws: {
+        getCredentials: () => new aws.Credentials(testCreds),
+      },
+    },
     service: {
       provider: {
         region: 'us-moon-1',
@@ -61,6 +77,14 @@ const constructPluginWithoutCertName = (basepath) => {
 };
 
 describe('Custom Domain Plugin', () => {
+  it('check aws config', () => {
+    const plugin = constructPlugin({}, 'tests');
+    const returnedCreds = plugin.apigateway.config.credentials;
+    console.log(returnedCreds)
+    expect(returnedCreds.accessKeyId).to.equal(testCreds.accessKeyId);
+    expect(returnedCreds.sessionToken).to.equal(testCreds.sessionToken);
+  });
+
   describe('Set Domain Name and Base Path', () => {
     const plugin = constructPlugin('test_basepath');
     let deploymentId = '';


### PR DESCRIPTION
You can now change the aws profile using either `--aws-profile` or edit the serverless file by adding profile under provider.