### PR TITLE
Ensure changeResourceRecordSet() fails silently

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+coverage/

--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ custom:
     domainName:
     stage:
     certificateName:
+    createRoute53Record: true
 ```
 If certificateName is not provided, the certificate will be chosen using the domain name.
 If certificateName is blank, an error will be thrown.
+If createRoute53Record is blank or not provided, it defaults to true.
 
 ## Running
 

--- a/index.js
+++ b/index.js
@@ -235,7 +235,7 @@ class ServerlessCustomDomain {
         const endPos = hostedZoneId.length;
         return hostedZoneId.substring(startPos, endPos);
       }
-      return null;
+      throw new Error(`${err} Unable to retrieve Route53 hosted zone id.`);
     })
     .catch((err) => {
       throw new Error(`${err} Unable to retrieve Route53 hosted zone id.`);

--- a/index.js
+++ b/index.js
@@ -235,7 +235,7 @@ class ServerlessCustomDomain {
         const endPos = hostedZoneId.length;
         return hostedZoneId.substring(startPos, endPos);
       }
-      throw new Error(`${err} Unable to retrieve Route53 hosted zone id.`);
+      return false;
     })
     .catch((err) => {
       throw new Error(`${err} Unable to retrieve Route53 hosted zone id.`);

--- a/index.js
+++ b/index.js
@@ -230,9 +230,7 @@ class ServerlessCustomDomain {
       }
       return null;
     })
-    .catch((err) => {
-        return null;
-    });
+    .catch(() => (null));
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -235,7 +235,7 @@ class ServerlessCustomDomain {
         const endPos = hostedZoneId.length;
         return hostedZoneId.substring(startPos, endPos);
       }
-      return false;
+      throw new Error('Could not find hosted zone.');
     })
     .catch((err) => {
       throw new Error(`${err} Unable to retrieve Route53 hosted zone id.`);

--- a/index.js
+++ b/index.js
@@ -237,7 +237,9 @@ class ServerlessCustomDomain {
       }
       return null;
     })
-    .catch(() => (null));
+    .catch((err) => {
+      throw new Error(`${err} Unable to retrieve Route53 hosted zone id.`);
+    });
   }
 
   /**
@@ -251,6 +253,11 @@ class ServerlessCustomDomain {
   changeResourceRecordSet(distributionDomainName, action) {
     if (action !== 'DELETE' && action !== 'CREATE') {
       throw new Error(`${action} is not a valid action. action must be either CREATE or DELETE`);
+    }
+
+    if (this.serverless.service.custom.customDomain.createRoute53Record !== undefined
+        && this.serverless.service.custom.customDomain.createRoute53Record === false) {
+      return Promise.resolve().then(() => (this.serverless.cli.log('Skipping creation of Route53 record.')));
     }
 
     return this.getHostedZoneId().then((hostedZoneId) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
Ensure `changeResourceRecordSet()` fails silently in case domain is not managed via Route53.

Also remove duplicate and unused `getHostedZoneId()` call.