### PR TITLE
:bug: fix(package): remove duplicate depencency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "mocha": "^2.2.5"
   },
   "dependencies": {
-    "aws-sdk": "^2.2.33",
-    "eslint-config-airbnb": "^14.1.0"
+    "aws-sdk": "^2.2.33"
   }
 }


### PR DESCRIPTION
As far as I can see it makes no sense to have the "eslint-config-airbnb"
dependency in both dependencies and devDependencies. This is a typical
devDepencency and having the package in there is sufficient. Adding the
package within dependecies can lead to conflicts with packages requiring
eslint as a peerDependency.