### PR TITLE
Make selection of target Domain Name in the Hosted zones predictable

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,8 @@ class ServerlessCustomDomain {
   setGivenDomainName(givenDomainName) {
     this.givenDomainName = givenDomainName;
     const firstDotPosition = this.givenDomainName.indexOf('.');
-    this.targetHostedZone = firstDotPosition === -1 ? this.givenDomainName : this.givenDomainName.substring(firstDotPosition + 1);
+    this.targetHostedZone = firstDotPosition === -1 ? this.givenDomainName
+      : this.givenDomainName.substring(firstDotPosition + 1);
   }
 
   setUpBasePathMapping() {

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ class ServerlessCustomDomain {
     this.givenDomainName = this.serverless.service.custom.customDomain.domainName;
     let firstDotPosition = this.givenDomainName.indexOf(".");
     this.targetHostedZone = this.givenDomainName.substring(firstDotPosition);
+    this.serverless.cli.log('Target hosted zone: ' + this.targetHostedZone);
   }
 
   createDomain() {
@@ -228,6 +229,9 @@ class ServerlessCustomDomain {
       let hostedZoneId = data.HostedZones.find((hostedZone) => {
         let hZoneName = hostedZone.Name;
         hZoneName = hZoneName.substr(0, hostedZone.Name.length - 1);   // Takes out the . at the end
+        this.serverless.cli.log('hZoneName = ' + hZoneName);
+        this.serverless.cli.log('targetHostedZone = ' + this.targetHostedZone);
+        this.serverless.cli.log('targetHostedZone === hZoneName' + (this.targetHostedZone === hZoneName));
         return (this.targetHostedZone === hZoneName);
       });
       hostedZoneId = hostedZoneId.Id;

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ class ServerlessCustomDomain {
     this.apigateway = new AWS.APIGateway();
     this.route53 = new AWS.Route53();
     this.givenDomainName = this.serverless.service.custom.customDomain.domainName;
-    let firstDotPosition = this.givenDomainName.indexOf(".");
+    const firstDotPosition = this.givenDomainName.indexOf('.');
     this.targetHostedZone = this.givenDomainName.substring(firstDotPosition + 1);
   }
 

--- a/index.js
+++ b/index.js
@@ -70,9 +70,7 @@ class ServerlessCustomDomain {
 
   setGivenDomainName(givenDomainName) {
     this.givenDomainName = givenDomainName;
-    const firstDotPosition = this.givenDomainName.indexOf('.');
-    this.targetHostedZone = firstDotPosition === -1 ? this.givenDomainName
-      : this.givenDomainName.substring(firstDotPosition + 1);
+    this.targetHostedZone = this.givenDomainName.substring(this.givenDomainName.indexOf('.') + 1);
   }
 
   setUpBasePathMapping() {
@@ -253,7 +251,7 @@ class ServerlessCustomDomain {
       let hostedZoneId = data.HostedZones.find((hostedZone) => {
         let hZoneName = hostedZone.Name;
         // Takes out the . at the end if there is one
-        hZoneName = hZoneName.substr(hostedZone.Name.length - 1) === '.' ? hZoneName.substr(0, hostedZone.Name.length - 1) : hZoneName;
+        hZoneName = hZoneName.endsWith('.') ? hZoneName.slice(0, -1) : hZoneName;
         return (this.targetHostedZone === hZoneName);
       });
       if (hostedZoneId) {

--- a/index.js
+++ b/index.js
@@ -41,6 +41,8 @@ class ServerlessCustomDomain {
     this.apigateway = new AWS.APIGateway();
     this.route53 = new AWS.Route53();
     this.givenDomainName = this.serverless.service.custom.customDomain.domainName;
+    let firstDotPosition = this.givenDomainName.indexOf(".");
+    this.targetHostedZone = this.givenDomainName.substring(firstDotPosition);
   }
 
   createDomain() {
@@ -226,7 +228,7 @@ class ServerlessCustomDomain {
       let hostedZoneId = data.HostedZones.find((hostedZone) => {
         let hZoneName = hostedZone.Name;
         hZoneName = hZoneName.substr(0, hostedZone.Name.length - 1);   // Takes out the . at the end
-        return this.givenDomainName.includes(hZoneName);
+        return (this.targetHostedZone === hZoneName);
       });
       hostedZoneId = hostedZoneId.Id;
       // Extracts the hostzone Id

--- a/index.js
+++ b/index.js
@@ -70,9 +70,7 @@ class ServerlessCustomDomain {
   setGivenDomainName(givenDomainName) {
     this.givenDomainName = givenDomainName;
     const firstDotPosition = this.givenDomainName.indexOf('.');
-    console.log("firstDotPosition = " + firstDotPosition);
     this.targetHostedZone = firstDotPosition === -1 ? this.givenDomainName : this.givenDomainName.substring(firstDotPosition + 1);
-    console.log("this.targetHostedZone = "+this.targetHostedZone);
   }
 
   setUpBasePathMapping() {
@@ -233,12 +231,10 @@ class ServerlessCustomDomain {
       // Gets the hostzone that contains the root of the custom domain name
       let hostedZoneId = data.HostedZones.find((hostedZone) => {
         let hZoneName = hostedZone.Name;
-        hZoneName = hZoneName.substr(hostedZone.Name.length - 1) === '.' ? hZoneName.substr(0, hostedZone.Name.length - 1) : hZoneName;   // Takes out the . at the end
-        console.log("hZoneName = " + hZoneName);
-        console.log("targetHostedZone = " + this.targetHostedZone);
+        // Takes out the . at the end if there is one
+        hZoneName = hZoneName.substr(hostedZone.Name.length - 1) === '.' ? hZoneName.substr(0, hostedZone.Name.length - 1) : hZoneName;
         return (this.targetHostedZone === hZoneName);
       });
-      console.log("Found hostedZoneId = " + hostedZoneId);
       hostedZoneId = hostedZoneId.Id;
       // Extracts the hostzone Id
       const startPos = hostedZoneId.indexOf('e/') + 2;

--- a/index.js
+++ b/index.js
@@ -42,8 +42,7 @@ class ServerlessCustomDomain {
     this.route53 = new AWS.Route53();
     this.givenDomainName = this.serverless.service.custom.customDomain.domainName;
     let firstDotPosition = this.givenDomainName.indexOf(".");
-    this.targetHostedZone = this.givenDomainName.substring(firstDotPosition);
-    this.serverless.cli.log('Target hosted zone: ' + this.targetHostedZone);
+    this.targetHostedZone = this.givenDomainName.substring(firstDotPosition + 1);
   }
 
   createDomain() {
@@ -229,9 +228,6 @@ class ServerlessCustomDomain {
       let hostedZoneId = data.HostedZones.find((hostedZone) => {
         let hZoneName = hostedZone.Name;
         hZoneName = hZoneName.substr(0, hostedZone.Name.length - 1);   // Takes out the . at the end
-        this.serverless.cli.log('hZoneName = ' + hZoneName);
-        this.serverless.cli.log('targetHostedZone = ' + this.targetHostedZone);
-        this.serverless.cli.log('targetHostedZone === hZoneName' + (this.targetHostedZone === hZoneName));
         return (this.targetHostedZone === hZoneName);
       });
       hostedZoneId = hostedZoneId.Id;

--- a/index.js
+++ b/index.js
@@ -40,9 +40,7 @@ class ServerlessCustomDomain {
     AWS.config.update(awsCreds);
     this.apigateway = new AWS.APIGateway();
     this.route53 = new AWS.Route53();
-    this.givenDomainName = this.serverless.service.custom.customDomain.domainName;
-    const firstDotPosition = this.givenDomainName.indexOf('.');
-    this.targetHostedZone = this.givenDomainName.substring(firstDotPosition + 1);
+    this.setGivenDomainName(this.serverless.service.custom.customDomain.domainName);
   }
 
   createDomain() {
@@ -67,6 +65,14 @@ class ServerlessCustomDomain {
     }).catch((err) => {
       throw new Error(`${err} ${this.givenDomainName} was not deleted.`);
     });
+  }
+
+  setGivenDomainName(givenDomainName) {
+    this.givenDomainName = givenDomainName;
+    const firstDotPosition = this.givenDomainName.indexOf('.');
+    console.log("firstDotPosition = " + firstDotPosition);
+    this.targetHostedZone = firstDotPosition === -1 ? this.givenDomainName : this.givenDomainName.substring(firstDotPosition + 1);
+    console.log("this.targetHostedZone = "+this.targetHostedZone);
   }
 
   setUpBasePathMapping() {
@@ -227,9 +233,12 @@ class ServerlessCustomDomain {
       // Gets the hostzone that contains the root of the custom domain name
       let hostedZoneId = data.HostedZones.find((hostedZone) => {
         let hZoneName = hostedZone.Name;
-        hZoneName = hZoneName.substr(0, hostedZone.Name.length - 1);   // Takes out the . at the end
+        hZoneName = hZoneName.substr(hostedZone.Name.length - 1) === '.' ? hZoneName.substr(0, hostedZone.Name.length - 1) : hZoneName;   // Takes out the . at the end
+        console.log("hZoneName = " + hZoneName);
+        console.log("targetHostedZone = " + this.targetHostedZone);
         return (this.targetHostedZone === hZoneName);
       });
+      console.log("Found hostedZoneId = " + hostedZoneId);
       hostedZoneId = hostedZoneId.Id;
       // Extracts the hostzone Id
       const startPos = hostedZoneId.indexOf('e/') + 2;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "engines": {
     "node": ">=4.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -97,7 +97,7 @@ describe('Custom Domain Plugin', () => {
       AWS.mock('ACM', 'listCertificates', certTestData);
 
       const plugin = constructPlugin('', null, true);
-      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
+      plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
 
 
       const result = await plugin.getCertArn();
@@ -122,7 +122,7 @@ describe('Custom Domain Plugin', () => {
 
       const plugin = constructPlugin(null, null, true);
       plugin.apigateway = new aws.APIGateway();
-      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
+      plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
 
 
       const result = await plugin.createDomainName('fake_cert');
@@ -141,8 +141,7 @@ describe('Custom Domain Plugin', () => {
 
       const plugin = constructPlugin('test_basepath', null, true);
       plugin.route53 = new aws.Route53();
-      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
-
+      plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
 
       const result = await plugin.changeResourceRecordSet('test_distribution_name', 'CREATE');
       const changes = result.ChangeBatch.Changes[0];
@@ -164,7 +163,7 @@ describe('Custom Domain Plugin', () => {
 
       const plugin = constructPlugin('test_basepath', null, true);
       plugin.apigateway = new aws.APIGateway();
-      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
+      plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
 
       const result = await plugin.getDomain();
 
@@ -181,7 +180,7 @@ describe('Custom Domain Plugin', () => {
 
       const plugin = constructPlugin('test_basepath', null, true);
       plugin.route53 = new aws.Route53();
-      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
+      plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
 
       const result = await plugin.changeResourceRecordSet('test_distribution_name', 'DELETE');
       const changes = result.ChangeBatch.Changes[0];
@@ -197,7 +196,7 @@ describe('Custom Domain Plugin', () => {
 
       const plugin = constructPlugin('test_basepath', null, true);
       plugin.apigateway = new aws.APIGateway();
-      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
+      plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
 
       const result = await plugin.clearDomainName();
       expect(result).to.eql({});
@@ -215,7 +214,7 @@ describe('Custom Domain Plugin', () => {
       });
       const plugin = constructPlugin('', null, true);
       plugin.apigateway = new aws.APIGateway();
-      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
+      plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
 
       await plugin.setUpBasePathMapping();
       const cfTemplat = plugin.serverless.service.provider.compiledCloudFormationTemplate.Resources;
@@ -237,7 +236,7 @@ describe('Custom Domain Plugin', () => {
       });
       const plugin = constructPlugin(null, null, true);
       plugin.apigateway = new aws.APIGateway();
-      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
+      plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
       plugin.route53 = new aws.Route53();
       const results = await plugin.deleteDomain();
       expect(results).to.equal('Domain was deleted.');
@@ -257,7 +256,7 @@ describe('Custom Domain Plugin', () => {
 
       const plugin = constructPlugin('', null, true);
       plugin.apigateway = new aws.APIGateway();
-      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
+      plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
       plugin.route53 = new aws.Route53();
       const result = await plugin.createDomain();
       expect(result).to.equal('Domain was created, may take up to 40 mins to be initialized.');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -18,7 +18,6 @@ const constructPlugin = (basepath, certName, stage, createRecord) => {
     cli: {
       log(params) { return params; },
       consoleLog(params) {
-        console.log(params);
         return params;
       },
     },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -286,16 +286,16 @@ describe('Custom Domain Plugin', () => {
   describe('Select Hosted Zone', () => {
     it('Natural order', async () => {
       AWS.mock('Route53', 'listHostedZones', (params, callback) => {
-        callback(null, {HostedZones: [{ Name: 'aaa.com.', Id: '/hostedzone/test_id_0' },
+        callback(null, { HostedZones: [{ Name: 'aaa.com.', Id: '/hostedzone/test_id_0' },
           { Name: 'bbb.aaa.com.', Id: '/hostedzone/test_id_1' },
           { Name: 'ccc.bbb.aaa.com.', Id: '/hostedzone/test_id_2' },
-          { Name: 'ddd.ccc.bbb.aaa.com.', Id: '/hostedzone/test_id_3' }]
+          { Name: 'ddd.ccc.bbb.aaa.com.', Id: '/hostedzone/test_id_3' }],
         });
       });
 
       const plugin = constructPlugin(null, null, null);
       plugin.route53 = new aws.Route53();
-      plugin.setGivenDomainName("test.ccc.bbb.aaa.com");
+      plugin.setGivenDomainName('test.ccc.bbb.aaa.com');
 
       const result = await plugin.getHostedZoneId();
       expect(result).to.equal('test_id_2');
@@ -303,16 +303,16 @@ describe('Custom Domain Plugin', () => {
 
     it('Reverse order', async () => {
       AWS.mock('Route53', 'listHostedZones', (params, callback) => {
-        callback(null, {HostedZones: [{ Name: 'ddd.ccc.bbb.aaa.com.', Id: '/hostedzone/test_id_0' },
+        callback(null, { HostedZones: [{ Name: 'ddd.ccc.bbb.aaa.com.', Id: '/hostedzone/test_id_0' },
           { Name: 'ccc.bbb.aaa.com.', Id: '/hostedzone/test_id_1' },
           { Name: 'bbb.aaa.com.', Id: '/hostedzone/test_id_2' },
-          { Name: 'aaa.com.', Id: '/hostedzone/test_id_3' }]
+          { Name: 'aaa.com.', Id: '/hostedzone/test_id_3' }],
         });
       });
 
       const plugin = constructPlugin(null, null, null);
       plugin.route53 = new aws.Route53();
-      plugin.setGivenDomainName("test.ccc.bbb.aaa.com");
+      plugin.setGivenDomainName('test.ccc.bbb.aaa.com');
 
       const result = await plugin.getHostedZoneId();
       expect(result).to.equal('test_id_1');
@@ -320,16 +320,16 @@ describe('Custom Domain Plugin', () => {
 
     it('Random order', async () => {
       AWS.mock('Route53', 'listHostedZones', (params, callback) => {
-        callback(null, {HostedZones: [{ Name: 'bbb.aaa.com.', Id: '/hostedzone/test_id_0' },
+        callback(null, { HostedZones: [{ Name: 'bbb.aaa.com.', Id: '/hostedzone/test_id_0' },
           { Name: 'ddd.ccc.bbb.aaa.com.', Id: '/hostedzone/test_id_1' },
           { Name: 'ccc.bbb.aaa.com.', Id: '/hostedzone/test_id_2' },
-          { Name: 'aaa.com.', Id: '/hostedzone/test_id_3' }]
+          { Name: 'aaa.com.', Id: '/hostedzone/test_id_3' }],
         });
       });
 
       const plugin = constructPlugin(null, null, null);
       plugin.route53 = new aws.Route53();
-      plugin.setGivenDomainName("test.ccc.bbb.aaa.com");
+      plugin.setGivenDomainName('test.ccc.bbb.aaa.com');
 
       const result = await plugin.getHostedZoneId();
       expect(result).to.equal('test_id_2');


### PR DESCRIPTION
First of all, let me **thank you** for a great plugin which simplified creation of Custom Domains in API Gateway, CNAMEs record in Route 53 and mapping them! **Very helpful and easy to use! Well done!**

The issue we had with the plugin was caused by the structure of our Domain Names in the Hosted Zones which reviewed the bug in the plugin's code. Please find the example and explanations below.

Let's assume, there are 2 domain names in your hosted zones:

```
    bbb.aaa.com.
ccc.bbb.aaa.com.
```

Let's assume, you want to create the following domain name:

```
custom:
  customDomain:
    ...
    domainName: test.ccc.bbb.aaa.com 
    ...
```

Question: In which domain name in your hosted zones the domain name above is going to be created: `bbb.aaa.com.` or `ccc.bbb.aaa.com.`?

Answer: **In current implementation it depends** because the code which determines that relies on the use of [`String.prototype.includes()`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/includes) function within [`Array.prototype.find()`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/find) function which `returns the value of the first element in the array that satisfies the provided testing function.` Here is the code I refer to in the [index.js](https://github.com/amplify-education/serverless-domain-manager/blob/master/index.js):

```
      // Gets the hostzone that contains the root of the custom domain name
      let hostedZoneId = data.HostedZones.find((hostedZone) => {
        let hZoneName = hostedZone.Name;
        hZoneName = hZoneName.substr(0, hostedZone.Name.length - 1);   // Takes out the . at the end
        return this.givenDomainName.includes(hZoneName);
      });
```

It effectively means, that

* if AWS API returns `[ 'bbb.aaa.com.', 'ccc.bbb.aaa.com.']` then custom domain is going to be created in `bbb.aaa.com.`
* if AWS API returns `[ 'ccc.bbb.aaa.com.', 'bbb.aaa.com.']` then custom domain is going to be created in `ccc.bbb.aaa.com.`

This behaviour is incorrect, because if custom domain `test.ccc.bbb.aaa.com` is created it should always be created in `ccc.bbb.aaa.com.` This Pull Request does exactly that by removing the first part of the specified custom domain name and comparing it to the items in the list of domain names received from the AWS API. 