### PR TITLE
DependsOn ApiGatewayStage if is defined in serverless.yml

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,19 +138,7 @@ class ServerlessCustomDomain {
       stage = service.provider.stage;
     }
 
-    // Creates the pathmapping
-    const pathmapping = {
-      Type: 'AWS::ApiGateway::BasePathMapping',
-      DependsOn: deployId,
-      Properties: {
-        BasePath: basePath,
-        DomainName: this.givenDomainName,
-        RestApiId: {
-          Ref: 'ApiGatewayRestApi',
-        },
-        Stage: stage,
-      },
-    };
+    const dependsOn = [deployId];
 
     // Verify the cloudFormationTemplate exists
     if (!service.provider.compiledCloudFormationTemplate) {
@@ -160,6 +148,25 @@ class ServerlessCustomDomain {
     if (!service.provider.compiledCloudFormationTemplate.Resources) {
       service.provider.compiledCloudFormationTemplate.Resources = {};
     }
+
+    // If user define an ApiGatewayStage resources add it into the dependsOn array
+    if (service.provider.compiledCloudFormationTemplate.Resources.ApiGatewayStage) {
+      dependsOn.push('ApiGatewayStage');
+    }
+
+    // Creates the pathmapping
+    const pathmapping = {
+      Type: 'AWS::ApiGateway::BasePathMapping',
+      DependsOn: dependsOn,
+      Properties: {
+        BasePath: basePath,
+        DomainName: this.givenDomainName,
+        RestApiId: {
+          Ref: 'ApiGatewayRestApi',
+        },
+        Stage: stage,
+      },
+    };
 
     // Creates and sets the resources
     service.provider.compiledCloudFormationTemplate.Resources.pathmapping = pathmapping;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "engines": {
     "node": ">=4.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -173,6 +173,33 @@ describe('Custom Domain Plugin', () => {
     });
   });
 
+
+  describe('Resource ApiGatewayStage overridden', () => {
+    const deploymentId = '';
+    it('serverless.yml doesn\'t define explicitly the resource ApiGatewayStage', () => {
+      const plugin = constructPlugin('');
+      plugin.addResources(deploymentId);
+      const cf = plugin.serverless.service.provider.compiledCloudFormationTemplate.Resources;
+
+      expect(cf.pathmapping.DependsOn).to.be.an('array').to.have.lengthOf(1);
+    });
+
+    it('serverless.yml defines explicitly the resource ApiGatewayStage', () => {
+      const plugin = constructPlugin('');
+      const cf = plugin.serverless.service.provider.compiledCloudFormationTemplate.Resources;
+
+      // Fake the property ApiGatewayStage
+      cf.ApiGatewayStage = {
+        Type: 'AWS::ApiGateway::Stage',
+        Properties: {},
+      };
+
+      plugin.addResources(deploymentId);
+      expect(cf.pathmapping.DependsOn).to.be.an('array').to.have.lengthOf(2);
+      expect(cf.pathmapping.DependsOn).to.include('ApiGatewayStage');
+    });
+  });
+
   describe('Delete the new domain', () => {
     it('Find available domains', async () => {
       AWS.mock('APIGateway', 'getDomainName', (params, callback) => {


### PR DESCRIPTION
Hi,

I use this plugin in conjunction with the plugin serverless-plugin-stage-variables. When I define a custom "ApiGatewayStage" into the resources sections the following error occurs:

```
Serverless: Deployment failed!
Serverless Error ---------------------------------------
An error occurred while provisioning your stack: pathmapping - Invalid stage identifier specified.
```

The "BasePathMapping" is created before the resource "ApiGatewayStage".

The PR handle the presence of the "ApiGatewayStage" to add it into DependsOn.