### PR TITLE
Add the ability to find adequat hosted zone

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
Find the most adequate hosted zone according to the given domain name

First find for hosted zone of lower level then go back to the higher level.


**Examples**
Case1:
 - givenDomainName: ccc.bbb.aaa.com
 - available hosted zones: bbb.aaa.com, aaa.com, ccc.aaa.com
 - selected hosted zone : bbb.aaa.com

Case2:
 - givenDomainName: ccc.bbb.aaa.com
 - available hosted zones: aaa.com, ccc.aaa.com
 - selected hosted zone : aaa.com

