### PR TITLE
Handle serverless deploy --package command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "engines": {
     "node": ">=4.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -66,10 +66,14 @@ const constructPlugin = (basepath, certName, stage, createRecord) => {
 describe('Custom Domain Plugin', () => {
   it('check aws config', () => {
     const plugin = constructPlugin({}, 'tests', true, true);
+    expect(plugin.initialized).to.equal(false);
+
     plugin.initializeVariables();
+
     const returnedCreds = plugin.apigateway.config.credentials;
     expect(returnedCreds.accessKeyId).to.equal(testCreds.accessKeyId);
     expect(returnedCreds.sessionToken).to.equal(testCreds.sessionToken);
+    expect(plugin.initialized).to.equal(true);
   });
 
   describe('Set Domain Name and Base Path', () => {


### PR DESCRIPTION
Hi,

I submit an another PR :)

Serverless offer the possibility to run the command "**serverless package**" and "**serverless deploy --package**" independently.

But in the plugin serverless-domain-manager, the variables are initialized only during the package phase:initialize and the deploy failed : 

> "Cannot read property 'getDomainName' of undefined" 

This is due to "this.apigateway" is undefined.

As Serverless doesn't offer phase deploy:initialize, I standardized the call of the function this.initializeVariables() to put it in each function that need variables.

