### PR TITLE
FIXED: IAM role permissions are corrected in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ Make sure you have the following installed before starting:
 
 The IAM role that is deploying the lambda will need the following permissions:
 ```
-acm: ListCertificate
+acm: ListCertificates
 apigateway: GET
 apigateway: POST
 route53: ListHostedZones
 route53: ChangeResourceRecordSets
+cloudfront: UpdateDistribution
 ```
 
 ## Installing


### PR DESCRIPTION
Fixed two IAM permissions in the README:
- Apparently there is no `ListCertificate` permission, only `ListCertificates` (see: http://docs.aws.amazon.com/acm/latest/userguide/authen-apipermissions.html).
- UpdateDistribution permission for CloudFront is also required for the `create_domain` operation (see: http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cf-api-permissions-ref.html).

Thanks for creating and maintaining this package!