### PR TITLE
Fix: Finding hosted zone id with matching root and sub hosted zones

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ class ServerlessCustomDomain {
 
   setGivenDomainName(givenDomainName) {
     this.givenDomainName = givenDomainName;
-    this.targetHostedZone = this.givenDomainName.substring(this.givenDomainName.indexOf('.') + 1);
+    this.targetHostedZoneName = this.givenDomainName.substring(this.givenDomainName.indexOf('.') + 1);
   }
 
   setUpBasePathMapping() {
@@ -270,7 +270,7 @@ class ServerlessCustomDomain {
         const targetHostedZone = data.HostedZones
           .filter((hostedZone) => {
             const hostedZoneName = hostedZone.Name.endsWith('.') ? hostedZone.Name.slice(0, -1) : hostedZone.Name;
-            return (this.targetHostedZone || '').endsWith(hostedZoneName);
+            return this.targetHostedZoneName.endsWith(hostedZoneName);
           })
           .sort((zone1, zone2) => zone2.Name.length - zone1.Name.length)
           .shift();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "engines": {
     "node": ">=4.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -382,6 +382,21 @@ describe('Custom Domain Plugin', () => {
       expect(result).to.equal('test_id_1');
     });
 
+    it('With matching root and sub hosted zone', async () => {
+      AWS.mock('Route53', 'listHostedZones', (params, callback) => {
+        callback(null, { HostedZones: [
+          { Name: 'a.aaa.com.', Id: '/hostedzone/test_id_0' },
+          { Name: 'aaa.com.', Id: '/hostedzone/test_id_1' }],
+        });
+      });
+
+      const plugin = constructPlugin(null, null, null);
+      plugin.route53 = new aws.Route53();
+      plugin.setGivenDomainName('test.a.aaa.com');
+
+      const result = await plugin.getHostedZoneId();
+      expect(result).to.equal('test_id_0');
+    });
 
     it('Sub domain name - natural order', async () => {
       AWS.mock('Route53', 'listHostedZones', (params, callback) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -477,7 +477,7 @@ describe('Custom Domain Plugin', () => {
 
       const plugin = constructPlugin();
       plugin.route53 = new aws.Route53();
-      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
+      plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
 
       return plugin.getHostedZoneId().then(() => {
         throw new Error('Test has failed, getHostedZone did not catch errors.');


### PR DESCRIPTION
There was an issue that function getHostedZoneId() would return incorrect hosted zone id if hosted zones contained two hosted zones with matching ending for example: 
sub.root.com
root.com

When using domain name test.sub.root.com getHostedZoneId returned id for root.com instead of sub.root.com because the find was just looking to match the ending.

Reproduced the scenario on the unit test and fixed the issue. Sorting of the hosted zones became obsolete after the fix.