### PR TITLE
Add Domain and Distribution to Stack Outputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,10 +199,10 @@ class ServerlessCustomDomain {
       service.provider.compiledCloudFormationTemplate.Outputs = {};
     }
     service.provider.compiledCloudFormationTemplate.Outputs.DomainName = {
-      Value: data.domainName
+      Value: data.domainName,
     };
     service.provider.compiledCloudFormationTemplate.Outputs.DistributionDomainName = {
-      Value: data.distributionDomainName
+      Value: data.distributionDomainName,
     };
   }
 

--- a/index.js
+++ b/index.js
@@ -84,9 +84,10 @@ class ServerlessCustomDomain {
   setUpBasePathMapping() {
     this.initializeVariables();
 
-    return this.getDomain().then(() => {
+    return this.getDomain().then((data) => {
       const deploymentId = this.getDeploymentId();
       this.addResources(deploymentId);
+      this.addOutputs(data);
     }).catch((err) => {
       throw new Error(`${err} Try running sls create_domain first.`);
     });
@@ -187,6 +188,22 @@ class ServerlessCustomDomain {
 
     // Creates and sets the resources
     service.provider.compiledCloudFormationTemplate.Resources.pathmapping = pathmapping;
+  }
+
+  /**
+   *  Adds the domain name and distribution domain name to the CloudFormation outputs
+   */
+  addOutputs(data) {
+    const service = this.serverless.service;
+    if (!service.provider.compiledCloudFormationTemplate.Outputs) {
+      service.provider.compiledCloudFormationTemplate.Outputs = {};
+    }
+    service.provider.compiledCloudFormationTemplate.Outputs.DomainName = {
+      Value: data.domainName
+    };
+    service.provider.compiledCloudFormationTemplate.Outputs.DistributionDomainName = {
+      Value: data.distributionDomainName
+    };
   }
 
   /*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "engines": {
     "node": ">=4.0"
   },
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.2.33",
-    "chalk": "^2.0.1"
+    "chalk": "^2.0.1",
+    "node": "^9.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {
     "aws-sdk": "^2.2.33",
-    "chalk": "^2.0.1",
-    "node": "^9.0.0"
+    "chalk": "^2.0.1"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -92,7 +92,7 @@ describe('Custom Domain Plugin', () => {
     });
 
     it('Add Domain Name and Distribution Name to stack output', () => {
-      plugin.addOutputs( {'domainName': 'fake_domain', 'distributionDomainName' : 'fake_dist_name'} );
+      plugin.addOutputs({ domainName: 'fake_domain', distributionDomainName: 'fake_dist_name' });
       const cfTemplat = plugin.serverless.service.provider.compiledCloudFormationTemplate.Outputs;
       expect(cfTemplat).to.not.equal(undefined);
     });
@@ -262,7 +262,7 @@ describe('Custom Domain Plugin', () => {
   describe('Hook Methods', () => {
     it('setupBasePathMapping', async () => {
       AWS.mock('APIGateway', 'getDomainName', (params, callback) => {
-        callback(null, { 'domainName': 'fake_domain', 'distributionDomainName': 'fake_dist_name'});
+        callback(null, { domainName: 'fake_domain', distributionDomainName: 'fake_dist_name' });
       });
       const plugin = constructPlugin('', null, true, true);
       plugin.apigateway = new aws.APIGateway();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -91,6 +91,12 @@ describe('Custom Domain Plugin', () => {
       expect(cfTemplat).to.not.equal(undefined);
     });
 
+    it('Add Domain Name and Distribution Name to stack output', () => {
+      plugin.addOutputs( {'domainName': 'fake_domain', 'distributionDomainName' : 'fake_dist_name'} );
+      const cfTemplat = plugin.serverless.service.provider.compiledCloudFormationTemplate.Outputs;
+      expect(cfTemplat).to.not.equal(undefined);
+    });
+
     it('(none) is added if empty basepath is given', () => {
       const emptyPlugin = constructPlugin('', null, true, true);
       emptyPlugin.addResources(deploymentId);
@@ -256,15 +262,16 @@ describe('Custom Domain Plugin', () => {
   describe('Hook Methods', () => {
     it('setupBasePathMapping', async () => {
       AWS.mock('APIGateway', 'getDomainName', (params, callback) => {
-        callback(null, params);
+        callback(null, { 'domainName': 'fake_domain', 'distributionDomainName': 'fake_dist_name'});
       });
       const plugin = constructPlugin('', null, true, true);
       plugin.apigateway = new aws.APIGateway();
       plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
 
       await plugin.setUpBasePathMapping();
-      const cfTemplat = plugin.serverless.service.provider.compiledCloudFormationTemplate.Resources;
-      expect(cfTemplat).to.not.equal(undefined);
+      const cfTemplat = plugin.serverless.service.provider.compiledCloudFormationTemplate;
+      expect(cfTemplat.Resources).to.not.equal(undefined);
+      expect(cfTemplat.Outputs).to.not.equal(undefined);
     });
 
     it('deleteDomain', async () => {


### PR DESCRIPTION
- Adds the domain name and distribution domain name to the CloudFormation stack outputs under the keys `DomainName` and `DistributionDomainName`, same information that we display in the domain summary.
Closes #43 