### PR TITLE
Fix Stage Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ custom:
 If certificateName is not provided, the certificate will be chosen using the domain name.
 If certificateName is blank, an error will be thrown.
 If createRoute53Record is blank or not provided, it defaults to true.
+Stage is optional, and if not specified will default to the user-provided stage option, or the
+stage specified in the provider section of serverless.yaml (Serverless defaults to 'dev' if this
+is unset).
 
 ## Running
 

--- a/index.js
+++ b/index.js
@@ -5,8 +5,9 @@ const chalk = require('chalk');
 
 class ServerlessCustomDomain {
 
-  constructor(serverless) {
+  constructor(serverless, options) {
     this.serverless = serverless;
+    this.options = options;
     // Indicate if variables are initialized to avoid run multiples init
     this.initialized = false;
 
@@ -150,10 +151,12 @@ class ServerlessCustomDomain {
     }
 
     let stage = service.custom.customDomain.stage;
-
-    // If stage is not provided, stage will be set based on the provider.
+    /*
+    If stage is not provided, stage will be set based on the user specified value
+    or the stage value of the provider section (which defaults to dev if unset)
+    */
     if (typeof stage === 'undefined') {
-      stage = service.provider.stage;
+      stage = this.options.stage || service.provider.stage;
     }
 
     const dependsOn = [deployId];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
Fixes how stage is set, making the stage attribute for the domain manager optional and respecting the stage if it's set via command line option (`--stage`) or in the provider section of the Serverless file.

Resolves #39 