### PR TITLE
Fix the 'create_domain' function

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,8 +54,8 @@ class ServerlessCustomDomain {
     this.initializeVariables();
 
     const createDomainName = this.getCertArn().then(data => this.createDomainName(data));
-    return Promise.all([createDomainName])
-      .then(values => this.changeResourceRecordSet(values[0], 'UPSERT'))
+    return createDomainName
+      .then(distributionDomainName => this.changeResourceRecordSet(distributionDomainName, 'UPSERT'))
       .then(() => (this.serverless.cli.log(`${this.givenDomainName} was created/updated. New domains may take up to 40 minutes to be initialized.`)))
       .catch((err) => {
         throw new Error(`${err} ${this.givenDomainName} was not created.`);

--- a/index.js
+++ b/index.js
@@ -55,11 +55,15 @@ class ServerlessCustomDomain {
 
     const createDomainName = this.getCertArn().then(data => this.createDomainName(data));
     return createDomainName
-      .then(distributionDomainName => this.changeResourceRecordSet(distributionDomainName, 'UPSERT'))
-      .then(() => (this.serverless.cli.log(`${this.givenDomainName} was created/updated. New domains may take up to 40 minutes to be initialized.`)))
       .catch((err) => {
-        throw new Error(`${err} ${this.givenDomainName} was not created.`);
-      });
+        throw new Error(`${err} ${this.givenDomainName} was not created in API Gateway.`);
+      })
+      .then((distributionDomainName) => {
+        this.changeResourceRecordSet(distributionDomainName, 'UPSERT').catch((err) => {
+          throw new Error(`${err} ${this.givenDomainName} was not created in Route53.`);
+        });
+      })
+      .then(() => (this.serverless.cli.log(`${this.givenDomainName} was created/updated. New domains may take up to 40 minutes to be initialized.`)));
   }
 
   deleteDomain() {

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ class ServerlessCustomDomain {
     const createDomainName = this.getCertArn().then(data => this.createDomainName(data));
     return Promise.all([createDomainName])
       .then(values => this.changeResourceRecordSet(values[0], 'UPSERT'))
-      .then(() => (this.serverless.cli.log('Domain was created/updated. New domains may take up to 40 min to be initialized.')))
+      .then(() => (this.serverless.cli.log(`${this.givenDomainName} was created/updated. New domains may take up to 40 minutes to be initialized.`)))
       .catch((err) => {
         throw new Error(`${err} ${this.givenDomainName} was not created.`);
       });

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ class ServerlessCustomDomain {
     const createDomainName = this.getCertArn().then(data => this.createDomainName(data));
     return Promise.all([createDomainName])
       .then(values => this.changeResourceRecordSet(values[0], 'UPSERT'))
-      .then(() => (this.serverless.cli.log('Domain was created, may take up to 40 mins to be initialized.')))
+      .then(() => (this.serverless.cli.log('Domain was created/updated. New domains may take up to 40 min to be initialized.')))
       .catch((err) => {
         throw new Error(`${err} ${this.givenDomainName} was not created.`);
       });

--- a/index.js
+++ b/index.js
@@ -363,11 +363,6 @@ class ServerlessCustomDomain {
       };
 
       return this.route53.changeResourceRecordSets(params).promise();
-    }, () => {
-      if (action === 'UPSERT') {
-        throw new Error(`Record set for ${this.givenDomainName} already exists.`);
-      }
-      throw new Error(`Record set for ${this.givenDomainName} does not exist and cannot be deleted.`);
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "engines": {
     "node": ">=4.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -162,16 +162,16 @@ describe('Custom Domain Plugin', () => {
       plugin.route53 = new aws.Route53();
       plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
 
-      const result = await plugin.changeResourceRecordSet('test_distribution_name', 'CREATE');
+      const result = await plugin.changeResourceRecordSet('test_distribution_name', 'UPSERT');
       const changes = result.ChangeBatch.Changes[0];
-      expect(changes.Action).to.equal('CREATE');
+      expect(changes.Action).to.equal('UPSERT');
       expect(changes.ResourceRecordSet.Name).to.equal('test_domain');
       expect(changes.ResourceRecordSet.ResourceRecords[0].Value).to.equal('test_distribution_name');
     });
 
     it('Do not create a Route53 record', async () => {
       const plugin = constructPlugin(null, null, true, false);
-      const result = await plugin.changeResourceRecordSet('test_distribution_name', 'CREATE');
+      const result = await plugin.changeResourceRecordSet('test_distribution_name', 'UPSERT');
       expect(result).to.equal('Skipping creation of Route53 record.');
     });
 
@@ -312,7 +312,7 @@ describe('Custom Domain Plugin', () => {
       plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
       plugin.route53 = new aws.Route53();
       const result = await plugin.createDomain();
-      expect(result).to.equal('Domain was created, may take up to 40 mins to be initialized.');
+      expect(result).to.equal('Domain was created/updated. New domains may take up to 40 min to be initialized.');
     });
 
     afterEach(() => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -312,7 +312,7 @@ describe('Custom Domain Plugin', () => {
       plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
       plugin.route53 = new aws.Route53();
       const result = await plugin.createDomain();
-      expect(result).to.equal('Domain was created/updated. New domains may take up to 40 min to be initialized.');
+      expect(result).to.equal('test_domain was created/updated. New domains may take up to 40 minutes to be initialized.');
     });
 
     afterEach(() => {


### PR DESCRIPTION
- Changes the Route53 action from `CREATE` to `UPSERT` when creating a domain so that the record creation doesn't fail if the resource record already exists.
- Queries API Gateway for the domain name, and doesn't issue a `createDomainName` call to API Gateway if the domain name is already associated with a distribution.

Fixes #41 