### PR TITLE
Feature: configurable hostedzoneid - fixes #65

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ custom:
     domainName:
     stage:
     certificateName:
+    hostedZoneId:    
     createRoute53Record: true
 ```
 For example:
@@ -74,6 +75,7 @@ If createRoute53Record is blank or not provided, it defaults to true.
 Stage is optional, and if not specified will default to the user-provided stage option, or the
 stage specified in the provider section of serverless.yaml (Serverless defaults to 'dev' if this
 is unset).
+If hostedZoneId is set the route53 record set will be created in the matching zone, otherwise the hosted zone will be figured out from the domainName (hosted zone with matching domain). Setting this parameter is specially useful if you have multiple hosted zones with the same domain name (e.g. a public and a private one).
 
 ## Running
 

--- a/index.js
+++ b/index.js
@@ -292,6 +292,12 @@ class ServerlessCustomDomain {
    * @return hostedZoneId or null if not found or access denied
    */
   getHostedZoneId() {
+    const specificId = this.serverless.service.custom.customDomain.hostedZoneId
+    if (specificId) {
+      this.serverless.cli.log(`Selected specific hostedZoneId ${specificId}`)
+      return Promise.resolve(specificId)
+    }
+    
     const hostedZonePromise = this.route53.listHostedZones({}).promise();
 
     return hostedZonePromise

--- a/index.js
+++ b/index.js
@@ -292,12 +292,12 @@ class ServerlessCustomDomain {
    * @return hostedZoneId or null if not found or access denied
    */
   getHostedZoneId() {
-    const specificId = this.serverless.service.custom.customDomain.hostedZoneId
+    const specificId = this.serverless.service.custom.customDomain.hostedZoneId;
     if (specificId) {
-      this.serverless.cli.log(`Selected specific hostedZoneId ${specificId}`)
-      return Promise.resolve(specificId)
+      this.serverless.cli.log(`Selected specific hostedZoneId ${specificId}`);
+      return Promise.resolve(specificId);
     }
-    
+
     const hostedZonePromise = this.route53.listHostedZones({}).promise();
 
     return hostedZonePromise

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.21",
+  "version": "1.2.0",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
Configuration option to set a specific Route53 `hosted zone id`.

Why:
- in the company I work for we have two hosted zone ids with the same domain (one is public and the other is private)
- because of the current `hostedzoneid` resolve strategy (`#getHostedZoneId` method) the DNS record set was being created in the "wrong hosted zone" (I had to create one in the public zone but it was being created in the private one)

Solution:
- make the plugin accept a `hostedZoneId` configuration option
- if the value is set use it, otherwise fallback to the current strategy

Example configuration:
```yml
plugins:
  - serverless-domain-manager
custom:
  customDomain:
    domainName: awesome-endpoint-${opt:stage}.mydomain.com
    basePath: ''
    stage: ${opt:stage}
    createRoute53Record: true
    certificateName: '*.mydomain.com'
    hostedZoneId: 1AM4N1D
```

*PS: for my case I already forked the repo and implemented the proposed solution. It is currently being used in our production environment*