### PR TITLE
Update README to Better Clarify Parameter Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Make sure you have the following installed before starting:
 The IAM role that is deploying the lambda will need the following permissions:
 ```
 acm:ListCertificates                *
-apigateway:GET                      /domainnames/* 
+apigateway:GET                      /domainnames/*
 apigateway:DELETE                   /domainnames/*
 apigateway:POST                     /domainnames
 cloudfront:UpdateDistribution       *
@@ -54,26 +54,31 @@ plugins:
 
 custom:
   customDomain:
-    basePath:
     domainName:
     stage:
+    basePath:
     certificateName:
-    createRoute53Record: true
+    createRoute53Record:
 ```
-For example:
+
+| Parameter Name | Default Value | Description |
+| --- | --- | --- |
+| `domainName` _(Required)_ | | The domain name to be created in API Gateway and Route53 (if enabled) for this API. |
+| `basePath` | `(none)` | The base path that will prepend all API endpoints. |
+| `stage` | Value of `--stage`, or `provider.stage` (serverless will default to `dev` if unset) | The stage to create the domain name for. This parameter allows you to specify a different stage for the domain name than the stage specified for the serverless deployment. |
+| `certificateName` | Closest match | The name of a specific certificate from Certificate Manager to use with this API. If not specified, the closest match will be used (i.e. for a given domain name `api.example.com`, a certificate for `api.example.com` will take precedence over a `*.example.com` certificate). <br><br> Note: Edge-optimized endpoints require that the certificate be located in `us-east-1` to be used with the CloudFront distribution. |
+| `createRoute53Record` | `true` | Toggles whether or not the plugin will create a CNAME record in Route53 mapping the `domainName` to to the generated distribution domain name. |
+
+Example configuration for an API with endpoints located at `serverless.foo.com/api`:
 ```yaml
 custom:
   customDomain:
-    basePath: "dev"
     domainName: serverless.foo.com
-    stage: dev
+    stage: ci
+    basePath: api
+    certificateName: *.foo.com
+    createRoute53Record: true
 ```
-If certificateName is not provided, the certificate will be chosen using the domain name.
-If certificateName is blank, an error will be thrown.
-If createRoute53Record is blank or not provided, it defaults to true.
-Stage is optional, and if not specified will default to the user-provided stage option, or the
-stage specified in the provider section of serverless.yaml (Serverless defaults to 'dev' if this
-is unset).
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -48,28 +48,16 @@ npm install https://github.com/amplify-education/serverless-domain-manager.git
 ```
 
 Then make the following edits to your serverless.yaml file:
+
+Add the plugin.
+
 ```yaml
 plugins:
   - serverless-domain-manager
-
-custom:
-  customDomain:
-    domainName:
-    stage:
-    basePath:
-    certificateName:
-    createRoute53Record:
 ```
 
-| Parameter Name | Default Value | Description |
-| --- | --- | --- |
-| `domainName` _(Required)_ | | The domain name to be created in API Gateway and Route53 (if enabled) for this API. |
-| `basePath` | `(none)` | The base path that will prepend all API endpoints. |
-| `stage` | Value of `--stage`, or `provider.stage` (serverless will default to `dev` if unset) | The stage to create the domain name for. This parameter allows you to specify a different stage for the domain name than the stage specified for the serverless deployment. |
-| `certificateName` | Closest match | The name of a specific certificate from Certificate Manager to use with this API. If not specified, the closest match will be used (i.e. for a given domain name `api.example.com`, a certificate for `api.example.com` will take precedence over a `*.example.com` certificate). <br><br> Note: Edge-optimized endpoints require that the certificate be located in `us-east-1` to be used with the CloudFront distribution. |
-| `createRoute53Record` | `true` | Toggles whether or not the plugin will create a CNAME record in Route53 mapping the `domainName` to to the generated distribution domain name. |
+Add the plugin configuration (example for `serverless.foo.com/api`).
 
-Example configuration for an API with endpoints located at `serverless.foo.com/api`:
 ```yaml
 custom:
   customDomain:
@@ -79,6 +67,15 @@ custom:
     certificateName: *.foo.com
     createRoute53Record: true
 ```
+
+| Parameter Name | Default Value | Description |
+| --- | --- | --- |
+| domainName _(Required)_ | | The domain name to be created in API Gateway and Route53 (if enabled) for this API. |
+| basePath | `(none)` | The base path that will prepend all API endpoints. |
+| stage | Value of `--stage`, or `provider.stage` (serverless will default to `dev` if unset) | The stage to create the domain name for. This parameter allows you to specify a different stage for the domain name than the stage specified for the serverless deployment. |
+| certificateName | Closest match | The name of a specific certificate from Certificate Manager to use with this API. If not specified, the closest match will be used (i.e. for a given domain name `api.example.com`, a certificate for `api.example.com` will take precedence over a `*.example.com` certificate). <br><br> Note: Edge-optimized endpoints require that the certificate be located in `us-east-1` to be used with the CloudFront distribution. |
+| createRoute53Record | `true` | Toggles whether or not the plugin will create a CNAME record in Route53 mapping the `domainName` to to the generated distribution domain name. |
+
 
 ## Running
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.21",
+  "version": "1.1.22",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
Adds a table of parameter names, default values, and descriptions to the README in an effort to reduce the confusion of configuration. 
Also updates the example configuration to show a deployment where all possible options are used.

Resolves #40 