### PR TITLE
Change Route53 Record Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Make sure you have the following installed before starting:
 The IAM role that is deploying the lambda will need the following permissions:
 ```
 acm:ListCertificates                *
-apigateway:GET                      /domainnames/* 
+apigateway:GET                      /domainnames/*
 apigateway:DELETE                   /domainnames/*
 apigateway:POST                     /domainnames
 cloudfront:UpdateDistribution       *
@@ -92,7 +92,7 @@ To remove the created custom domain:
 serverless delete_domain
 ```
 # How it works
-Creating the custom domain takes advantage of Amazon's Certificate Manager to assign a certificate to the given domain name. Based on already created certificate names, the plugin will search for the certificate that resembles the custom domain's name the most and assign the ARN to that domain name. The plugin then creates the proper CNAMEs for the domain through Route 53. Once the domain name is set it takes up to 40 minutes before it is initialized. After the certificate is initialized, `sls deploy` will create the base path mapping and assign the lambda to the custom domain name through Cloudfront.
+Creating the custom domain takes advantage of Amazon's Certificate Manager to assign a certificate to the given domain name. Based on already created certificate names, the plugin will search for the certificate that resembles the custom domain's name the most and assign the ARN to that domain name. The plugin then creates the proper A Alias records for the domain through Route 53. Once the domain name is set it takes up to 40 minutes before it is initialized. After the certificate is initialized, `sls deploy` will create the base path mapping and assign the lambda to the custom domain name through CloudFront.
 
 ## Running Tests
 To run the test:

--- a/index.js
+++ b/index.js
@@ -319,6 +319,10 @@ class ServerlessCustomDomain {
    *                  The CNAME is specified in the serverless file under domainName
    */
   changeResourceRecordSet(distributionDomainName, action) {
+    /* Constant for the hosted zone of API Gateway CloudFront distributions.
+       <http://docs.aws.amazon.com/general/latest/gr/rande.html#cf_region> */
+    const cloudfrontHostedZoneID = 'Z2FDTNDATAQYW2';
+
     if (action !== 'DELETE' && action !== 'CREATE') {
       throw new Error(`${action} is not a valid action. action must be either CREATE or DELETE`);
     }
@@ -340,17 +344,16 @@ class ServerlessCustomDomain {
               Action: action,
               ResourceRecordSet: {
                 Name: this.givenDomainName,
-                ResourceRecords: [
-                  {
-                    Value: distributionDomainName,
-                  },
-                ],
-                TTL: 60,
-                Type: 'CNAME',
+                Type: 'A',
+                AliasTarget: {
+                  DNSName: distributionDomainName,
+                  EvaluateTargetHealth: false,
+                  HostedZoneId: cloudfrontHostedZoneID,
+                },
               },
             },
           ],
-          Comment: 'Created from Serverless Custom Domain Name',
+          Comment: 'Record created by serverless-domain-manager',
         },
         HostedZoneId: hostedZoneId,
       };

--- a/index.js
+++ b/index.js
@@ -94,17 +94,22 @@ class ServerlessCustomDomain {
 
   setGivenDomainName(givenDomainName) {
     this.givenDomainName = givenDomainName;
-    this.targetHostedZoneName = this.givenDomainName.substring(this.givenDomainName.indexOf('.') + 1);
   }
 
   setUpBasePathMapping() {
     this.initializeVariables();
 
+    let domainData = null;
     return this.getDomain().then((data) => {
+      domainData = data;
+      return this.migrateRecordType(data.distributionDomainName);
+    })
+    .then(() => {
       const deploymentId = this.getDeploymentId();
       this.addResources(deploymentId);
-      this.addOutputs(data);
-    }).catch((err) => {
+      this.addOutputs(domainData);
+    })
+    .catch((err) => {
       throw new Error(`Error: Could not set up basepath mapping. Try running sls create_domain first.\n${err}`);
     });
   }

--- a/index.js
+++ b/index.js
@@ -66,11 +66,9 @@ class ServerlessCustomDomain {
         distDomainName = distributionDomainName;
         return this.migrateRecordType(distDomainName);
       })
-      .then(() => {
-        return this.changeResourceRecordSet(distDomainName, 'UPSERT').catch((err) => {
-          throw new Error(`Error: '${this.givenDomainName}' was not created in Route53.\n${err}`);
-        });
-      })
+      .then(() => this.changeResourceRecordSet(distDomainName, 'UPSERT').catch((err) => {
+        throw new Error(`Error: '${this.givenDomainName}' was not created in Route53.\n${err}`);
+      }))
       .then(() => (this.serverless.cli.log(`'${this.givenDomainName}' was created/updated. New domains may take up to 40 minutes to be initialized.`)));
   }
 
@@ -399,7 +397,7 @@ class ServerlessCustomDomain {
 
     return this.getHostedZoneId().then((hostedZoneId) => {
       if (!hostedZoneId) {
-        return;
+        return null;
       }
 
       const params = {

--- a/index.js
+++ b/index.js
@@ -407,10 +407,8 @@ class ServerlessCustomDomain {
       };
 
       this.route53.changeResourceRecordSets(params).then(() => {
-        this.serverless.cli.log("Notice: Legacy CNAME record was removed");
-      }).catch(() => {  // Swallow the exception, not an error if it doesn't exist.
-        return;
-      });
+        this.serverless.cli.log('Notice: Legacy CNAME record was removed');
+      }).catch(() => {});  // Swallow the exception, not an error if it doesn't exist.
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ class ServerlessCustomDomain {
         throw new Error(`Error: '${this.givenDomainName}' was not created in API Gateway.\n${err}`);
       })
       .then((distributionDomainName) => {
+        this.deleteCNAME(distributionDomainName);
         this.changeResourceRecordSet(distributionDomainName, 'UPSERT').catch((err) => {
           throw new Error(`Error: '${this.givenDomainName}' was not created in Route53.\n${err}`);
         });
@@ -70,6 +71,7 @@ class ServerlessCustomDomain {
     this.initializeVariables();
 
     return this.getDomain().then((data) => {
+      this.deleteCNAME(data.distributionDomainName);
       const promises = [
         this.changeResourceRecordSet(data.distributionDomainName, 'DELETE'),
         this.clearDomainName(),

--- a/index.js
+++ b/index.js
@@ -430,7 +430,7 @@ class ServerlessCustomDomain {
       };
 
       const changeRecords = this.route53.changeResourceRecordSets(params).promise();
-      changeRecords.then((data) => this.serverless.cli.log("Notice: Legacy CNAME record was replaced with an A Alias record"))
+      changeRecords.then(() => this.serverless.cli.log('Notice: Legacy CNAME record was replaced with an A Alias record'))
         .catch(() => {}); // Swallow the error, not an error if it doesn't exist
     });
   }

--- a/index.js
+++ b/index.js
@@ -80,13 +80,13 @@ class ServerlessCustomDomain {
       distDomainName = data.distributionDomainName;
       return this.migrateRecordType(distDomainName);
     })
-    .then(() => {
+      .then(() => {
         const promises = [
           this.changeResourceRecordSet(distDomainName, 'DELETE'),
           this.clearDomainName(),
         ];
         return (Promise.all(promises).then(() => (this.serverless.cli.log('Domain was deleted.'))));
-    })
+      })
     .catch((err) => {
       throw new Error(`Error: '${this.givenDomainName}' was not deleted.\n${err}`);
     });
@@ -104,11 +104,11 @@ class ServerlessCustomDomain {
       domainData = data;
       return this.migrateRecordType(data.distributionDomainName);
     })
-    .then(() => {
-      const deploymentId = this.getDeploymentId();
+      .then(() => {
+        const deploymentId = this.getDeploymentId();
         this.addResources(deploymentId);
         this.addOutputs(domainData);
-    })
+      })
     .catch((err) => {
       throw new Error(`Error: Could not set up basepath mapping. Try running sls create_domain first.\n${err}`);
     });

--- a/index.js
+++ b/index.js
@@ -81,11 +81,11 @@ class ServerlessCustomDomain {
       return this.migrateRecordType(distDomainName);
     })
     .then(() => {
-      const promises = [
-        this.changeResourceRecordSet(distDomainName, 'DELETE'),
-        this.clearDomainName(),
-      ];
-      return (Promise.all(promises).then(() => (this.serverless.cli.log('Domain was deleted.'))));
+        const promises = [
+          this.changeResourceRecordSet(distDomainName, 'DELETE'),
+          this.clearDomainName(),
+        ];
+        return (Promise.all(promises).then(() => (this.serverless.cli.log('Domain was deleted.'))));
     })
     .catch((err) => {
       throw new Error(`Error: '${this.givenDomainName}' was not deleted.\n${err}`);
@@ -106,8 +106,8 @@ class ServerlessCustomDomain {
     })
     .then(() => {
       const deploymentId = this.getDeploymentId();
-      this.addResources(deploymentId);
-      this.addOutputs(domainData);
+        this.addResources(deploymentId);
+        this.addOutputs(domainData);
     })
     .catch((err) => {
       throw new Error(`Error: Could not set up basepath mapping. Try running sls create_domain first.\n${err}`);

--- a/index.js
+++ b/index.js
@@ -311,12 +311,12 @@ class ServerlessCustomDomain {
   }
 
   /**
-   * Can create a new CNAME or delete a CNAME
+   * Can create a new A Alias or delete a A Alias
    *
    * @param distributionDomainName    the domain name of the cloudfront
-   * @param action    CREATE: Creates a CNAME
-   *                  DELETE: Deletes the CNAME
-   *                  The CNAME is specified in the serverless file under domainName
+   * @param action    CREATE: Creates a A Alias
+   *                  DELETE: Deletes the A Alias
+   *                  The A Alias is specified in the serverless file under domainName
    */
   changeResourceRecordSet(distributionDomainName, action) {
     /* Constant for the hosted zone of API Gateway CloudFront distributions.

--- a/index.js
+++ b/index.js
@@ -314,7 +314,7 @@ class ServerlessCustomDomain {
         const targetHostedZone = data.HostedZones
           .filter((hostedZone) => {
             const hostedZoneName = hostedZone.Name.endsWith('.') ? hostedZone.Name.slice(0, -1) : hostedZone.Name;
-            return this.targetHostedZoneName.endsWith(hostedZoneName);
+            return this.givenDomainName.endsWith(hostedZoneName);
           })
           .sort((zone1, zone2) => zone2.Name.length - zone1.Name.length)
           .shift();
@@ -326,7 +326,7 @@ class ServerlessCustomDomain {
           const endPos = hostedZoneId.length;
           return hostedZoneId.substring(startPos, endPos);
         }
-        throw new Error(`Error: Could not find hosted zone '${this.targetHostedZoneName}'`);
+        throw new Error(`Error: Could not find hosted zone '${this.givenDomainName}'`);
       });
   }
 

--- a/index.js
+++ b/index.js
@@ -417,9 +417,9 @@ class ServerlessCustomDomain {
         HostedZoneId: hostedZoneId,
       };
 
-      this.route53.changeResourceRecordSets(params).then(() => {
-        this.serverless.cli.log('Notice: Legacy CNAME record was removed');
-      }).catch(() => {});  // Swallow the exception, not an error if it doesn't exist.
+      const changeRecords = this.route53.changeResourceRecordSets(params).promise();
+      changeRecords.then((data) => this.serverless.cli.log("Notice: Legacy CNAME record was removed."))
+        .catch(() => {}); // Swallow the error, not an error if it doesn't exist
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -333,7 +333,7 @@ class ServerlessCustomDomain {
     const cloudfrontHostedZoneID = 'Z2FDTNDATAQYW2';
 
     if (action !== 'DELETE' && action !== 'UPSERT') {
-      throw new Error(`${action} is not a valid action. action must be either UPSERT or DELETE`);
+      throw new Error(`Error: ${action} is not a valid action. action must be either UPSERT or DELETE`);
     }
 
     if (this.serverless.service.custom.customDomain.createRoute53Record !== undefined

--- a/index.js
+++ b/index.js
@@ -415,13 +415,9 @@ class ServerlessCustomDomain {
         HostedZoneId: hostedZoneId,
       };
 
-<<<<<<< HEAD
       this.route53.changeResourceRecordSets(params).then(() => {
         this.serverless.cli.log('Notice: Legacy CNAME record was removed');
       }).catch(() => {});  // Swallow the exception, not an error if it doesn't exist.
-=======
-      return this.route53.changeResourceRecordSets(params).promise();
->>>>>>> master
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.21",
+  "version": "1.2.0",
   "engines": {
     "node": ">=4.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -154,25 +154,22 @@ describe('Custom Domain Plugin', () => {
         callback(null, { HostedZones: [{ Name: 'test_domain', Id: 'test_id' }] });
       });
       AWS.mock('Route53', 'changeResourceRecordSets', (params, callback) => {
-        callback(null, params);
-      });
+        const changes = params.ChangeBatch.Changes;
+        expect(changes[0].Action).to.equal('DELETE');
+        expect(changes[0].ResourceRecordSet.Type).to.equal('CNAME');
+        expect(changes[0].ResourceRecordSet.Name).to.equal('test_domain');
+        expect(changes[0].ResourceRecordSet.ResourceRecords[0].Value).to.equal('test_distribution_name');
 
+        expect(changes[1].Action).to.equal('CREATE');
+        expect(changes[1].ResourceRecordSet.Type).to.equal('A');
+        expect(changes[1].ResourceRecordSet.Name).to.equal('test_domain');
+        expect(changes[1].ResourceRecordSet.AliasTarget.DNSName).to.equal('test_distribution_name');
+        callback(null, null);
+      });
       const plugin = constructPlugin('test_basepath', null, true, true);
       plugin.route53 = new aws.Route53();
       plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
-
-      const result = await plugin.migrateRecordType('test_distribution_name');
-      const changes = result.ChangeBatch.Changes;
-
-      expect(changes[0].Action).to.equal('DELETE');
-      expect(changes[0].ResourceRecordSet.Type).to.equal('CNAME');
-      expect(changes[0].ResourceRecordSet.Name).to.equal('test_domain');
-      expect(changes[0].ResourceRecordSet.ResourceRecords[0].Value).to.equal('test_distribution_name');
-
-      expect(changes[1].Action).to.equal('CREATE');
-      expect(changes[1].ResourceRecordSet.Type).to.equal('A');
-      expect(changes[1].ResourceRecordSet.Name).to.equal('test_domain');
-      expect(changes[1].ResourceRecordSet.AliasTarget.DNSName).to.equal('test_distribution_name');
+      await plugin.migrateRecordType('test_distribution_name');
     });
 
     it('Create a new A Alias Record', async () => {
@@ -533,6 +530,18 @@ describe('Custom Domain Plugin', () => {
         const expectedErrorMessage = "Error: Domain manager summary logging failed.\nTypeError: Cannot read property 'distributionDomainName' of null";
         expect(err.message).to.equal(expectedErrorMessage);
       });
+    });
+    it('Catch failure of record type migration', async () => {
+      AWS.mock('Route53', 'listHostedZones', (params, callback) => {
+        callback(null, { HostedZones: [{ Name: 'test_domain', Id: 'test_id' }] });
+      });
+      AWS.mock('Route53', 'changeResourceRecordSets', (params, callback) => {
+        callback(new Error('CNAME does\'t exist, but that\'s ok'), null);
+      });
+      const plugin = constructPlugin('test_basepath', null, true, true);
+      plugin.route53 = new aws.Route53();
+      plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
+      await plugin.migrateRecordType('test_distribution_name');
     });
 
     afterEach(() => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -286,6 +286,12 @@ describe('Custom Domain Plugin', () => {
       AWS.mock('APIGateway', 'getDomainName', (params, callback) => {
         callback(null, { domainName: 'fake_domain', distributionDomainName: 'fake_dist_name' });
       });
+      AWS.mock('Route53', 'listHostedZones', (params, callback) => {
+        callback(null, { HostedZones: [{ Name: 'test_domain', Id: 'test_id' }] });
+      });
+      AWS.mock('Route53', 'changeResourceRecordSets', (params, callback) => {
+        callback(null, null);
+      });
       const plugin = constructPlugin('', null, true, true);
       plugin.apigateway = new aws.APIGateway();
       plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
@@ -354,7 +360,7 @@ describe('Custom Domain Plugin', () => {
 
       const plugin = constructPlugin(null, null, null);
       plugin.route53 = new aws.Route53();
-      plugin.setGivenDomainName('test.ccc.bbb.aaa.com');
+      plugin.setGivenDomainName('ccc.bbb.aaa.com');
 
       const result = await plugin.getHostedZoneId();
       expect(result).to.equal('test_id_2');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -150,7 +150,7 @@ describe('Custom Domain Plugin', () => {
     });
 
 
-    it('Create a new CNAME', async () => {
+    it('Create a new A Alias Record', async () => {
       AWS.mock('Route53', 'listHostedZones', (params, callback) => {
         callback(null, { HostedZones: [{ Name: 'test_domain', Id: 'test_id' }] });
       });
@@ -166,7 +166,7 @@ describe('Custom Domain Plugin', () => {
       const changes = result.ChangeBatch.Changes[0];
       expect(changes.Action).to.equal('CREATE');
       expect(changes.ResourceRecordSet.Name).to.equal('test_domain');
-      expect(changes.ResourceRecordSet.ResourceRecords[0].Value).to.equal('test_distribution_name');
+      expect(changes.ResourceRecordSet.AliasTarget.DNSName).to.equal('test_distribution_name');
     });
 
     it('Do not create a Route53 record', async () => {
@@ -222,7 +222,7 @@ describe('Custom Domain Plugin', () => {
       expect(result.domainName).to.equal('test_domain');
     });
 
-    it('Delete CNAME', async () => {
+    it('Delete A Alias Record', async () => {
       AWS.mock('Route53', 'listHostedZones', (params, callback) => {
         callback(null, { HostedZones: [{ Name: 'test_domain', Id: 'test_id' }] });
       });
@@ -238,7 +238,7 @@ describe('Custom Domain Plugin', () => {
       const changes = result.ChangeBatch.Changes[0];
       expect(changes.Action).to.equal('DELETE');
       expect(changes.ResourceRecordSet.Name).to.equal('test_domain');
-      expect(changes.ResourceRecordSet.ResourceRecords[0].Value).to.equal('test_distribution_name');
+      expect(changes.ResourceRecordSet.AliasTarget.DNSName).to.equal('test_distribution_name');
     });
 
     it('Delete the domain name', async () => {


### PR DESCRIPTION
Currently we create CNAME records in Route53 to map the custom domain name to the API Gateway CloudFront distribution, and this doesn't allow APIs to be deployed to the zone apex of the hosted zone. By changing the record type used to AWS-specific A alias records, we can now support deployment of an API to the zone apex, as they function identically to CNAME records without the restriction of overlapping records.

To keep this update non-breaking, a `migrateRecordType` method is added that will run when a domain is created, deleted, or the service is packaged/deployed in order to gracefully phase out the use of CNAME records.

An assumption was also present that the domain would always be a subdomain of a hosted zone, so that had to be changed as well to support the custom domain being equal to the zone apex.

Resolves #44 and #69 
Resolves #78 