### PR TITLE
Fix 'basePath' Parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For example:
 ```yaml
 custom:
   customDomain:
-    basePath: "dev"
+    basePath: dev
     domainName: serverless.foo.com
     stage: dev
 ```

--- a/index.js
+++ b/index.js
@@ -149,8 +149,8 @@ class ServerlessCustomDomain {
 
     let basePath = service.custom.customDomain.basePath;
 
-    // Base path cannot be empty, instead it must be (none)
-    if (basePath.trim() === '') {
+    // Check that basePath is either not set, or set to an empty string
+    if (basePath == null || basePath.trim() === '') {
       basePath = '(none)';
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.21",
+  "version": "1.1.22",
   "engines": {
     "node": ">=4.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -97,8 +97,22 @@ describe('Custom Domain Plugin', () => {
       expect(cfTemplat).to.not.equal(undefined);
     });
 
-    it('(none) is added if empty basepath is given', () => {
+    it('(none) is added if basepath is an empty string', () => {
       const emptyPlugin = constructPlugin('', null, true, true);
+      emptyPlugin.addResources(deploymentId);
+      const cf = emptyPlugin.serverless.service.provider.compiledCloudFormationTemplate.Resources;
+      expect(cf.pathmapping.Properties.BasePath).to.equal('(none)');
+    });
+
+    it('(none) is added if no value is given for basepath (null)', () => {
+      const emptyPlugin = constructPlugin(null, null, true, true);
+      emptyPlugin.addResources(deploymentId);
+      const cf = emptyPlugin.serverless.service.provider.compiledCloudFormationTemplate.Resources;
+      expect(cf.pathmapping.Properties.BasePath).to.equal('(none)');
+    });
+
+    it('(none) is added if basepath attribute is missing (undefined)', () => {
+      const emptyPlugin = constructPlugin(undefined, null, true, true);
       emptyPlugin.addResources(deploymentId);
       const cf = emptyPlugin.serverless.service.provider.compiledCloudFormationTemplate.Resources;
       expect(cf.pathmapping.Properties.BasePath).to.equal('(none)');


### PR DESCRIPTION
Currently the `basePath` parameter in the `customDomain` configuration must be set to an empty string if the user does not wish to have a base path. Fix this so that the basePath can be omitted without the plugin breaking.