### PR TITLE
Update Recommended Install Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Alternatively you can generate an least privileged IAM Managed Policy for deploy
 ## Installing
 ```
 # From npm (recommended)
-npm install serverless-domain-manager
+npm install serverless-domain-manager --save-dev
 
 # From github
 npm install https://github.com/amplify-education/serverless-domain-manager.git

--- a/README.md
+++ b/README.md
@@ -43,9 +43,6 @@ Alternatively you can generate an least privileged IAM Managed Policy for deploy
 ```
 # From npm (recommended)
 npm install serverless-domain-manager --save-dev
-
-# From github
-npm install https://github.com/amplify-education/serverless-domain-manager.git
 ```
 
 Then make the following edits to your serverless.yaml file:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.21",
+  "version": "1.1.22",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "1.1.22",
+  "version": "1.1.24",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
As @doublemarked pointed out, the domain manager can be installed using `--save-dev` to avoid it being included in deployment artifacts. It probably makes sense to add this as the recommended way to install the plugin to the README.

Resolves #61