### PR TITLE
Inherit AWS options from serverless AWS SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules/
 coverage
 npm-debug.log
+*.iml

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ custom:
 | createRoute53Record | `true` | Toggles whether or not the plugin will create a CNAME record in Route53 mapping the `domainName` to the generated distribution domain name. |
 | endpointType | edge | Defines the endpoint type, accepts `regional` or `edge`. |
 | hostedZoneId | | If hostedZoneId is set the route53 record set will be created in the matching zone, otherwise the hosted zone will be figured out from the domainName (hosted zone with matching domain). Setting this parameter is specially useful if you have multiple hosted zones with the same domain name (e.g. a public and a private one) |
+| enabled | true | Sometimes there are stages for which is not desired to have custom domain names. This flag allows the developer to disable the plugin for such cases. Accepts only `boolean` values and defaults to `true` for backwards compatibility. |
 
 ## Running
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const AWS = require('aws-sdk');
 const chalk = require('chalk');
 const DomainResponse = require('./DomainResponse');
 
@@ -48,15 +47,15 @@ class ServerlessCustomDomain {
     if (!this.initialized) {
       this.enabled = this.evaluateEnabled();
       if (this.enabled) {
-        // Sets the credentials for AWS resources.
-        const awsCreds = this.serverless.providers.aws.getCredentials();
-        AWS.config.update(awsCreds);
-        this.apigateway = new AWS.APIGateway();
-        this.route53 = new AWS.Route53();
+        this.apigateway = new this.serverless.providers.aws.sdk.APIGateway({
+          region: this.serverless.providers.aws.getRegion(),
+        });
+        this.route53 = new this.serverless.providers.aws.sdk.Route53();
         this.setGivenDomainName(this.serverless.service.custom.customDomain.domainName);
         this.setEndpointType(this.serverless.service.custom.customDomain.endpointType);
         this.setAcmRegion();
       }
+
       this.initialized = true;
     }
   }
@@ -323,7 +322,7 @@ class ServerlessCustomDomain {
    * Obtains the certification arn
    */
   getCertArn() {
-    const acm = new AWS.ACM({
+    const acm = new this.serverless.providers.aws.sdk.ACM({
       region: this.acmRegion,
     });
 

--- a/index.js
+++ b/index.js
@@ -54,6 +54,9 @@ class ServerlessCustomDomain {
         this.setGivenDomainName(this.serverless.service.custom.customDomain.domainName);
         this.setEndpointType(this.serverless.service.custom.customDomain.endpointType);
         this.setAcmRegion();
+        this.acm = new this.serverless.providers.aws.sdk.ACM({
+          region: this.acmRegion,
+        });
       }
 
       this.initialized = true;
@@ -322,11 +325,7 @@ class ServerlessCustomDomain {
    * Obtains the certification arn
    */
   getCertArn() {
-    const acm = new this.serverless.providers.aws.sdk.ACM({
-      region: this.acmRegion,
-    });
-
-    const certArn = acm.listCertificates().promise();
+    const certArn = this.acm.listCertificates().promise();
 
     return certArn.catch((err) => {
       throw Error(`Error: Could not list certificates in Certificate Manager.\n${err}`);

--- a/index.js
+++ b/index.js
@@ -174,12 +174,15 @@ class ServerlessCustomDomain {
 
     return this.getDomain().then((data) => {
       this.serverless.cli.consoleLog(chalk.yellow.underline('Serverless Domain Manager Summary'));
+
       if (this.serverless.service.custom.customDomain.createRoute53Record !== false) {
         this.serverless.cli.consoleLog(chalk.yellow('Domain Name'));
         this.serverless.cli.consoleLog(`  ${this.givenDomainName}`);
       }
+
       this.serverless.cli.consoleLog(chalk.yellow('Distribution Domain Name'));
-      this.serverless.cli.consoleLog(`  ${data.distributionDomainName}`);
+      this.serverless.cli.consoleLog(`  ${data.domainName}`);
+
       return true;
     }).catch((err) => {
       throw new Error(`Error: Domain manager summary logging failed.\n${err}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "engines": {
     "node": ">=4.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -167,8 +167,8 @@ describe('Custom Domain Plugin', () => {
 
       const plugin = constructPlugin('', null, true, true);
       plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
-
       plugin.setEndpointType('REGIONAL');
+      plugin.acm = new aws.ACM();
 
       const result = await plugin.getCertArn();
 
@@ -179,6 +179,7 @@ describe('Custom Domain Plugin', () => {
       AWS.mock('ACM', 'listCertificates', certTestData);
 
       const plugin = constructPlugin('', 'cert_name', true, true);
+      plugin.acm = new aws.ACM();
 
       const result = await plugin.getCertArn();
 
@@ -396,6 +397,7 @@ describe('Custom Domain Plugin', () => {
       plugin.apigateway = new aws.APIGateway();
       plugin.setGivenDomainName(plugin.serverless.service.custom.customDomain.domainName);
       plugin.route53 = new aws.Route53();
+      plugin.acm = new aws.ACM();
       const result = await plugin.createDomain();
       expect(result).to.equal('\'test_domain\' was created/updated. New domains may take up to 40 minutes to be initialized.');
     });
@@ -561,6 +563,7 @@ describe('Custom Domain Plugin', () => {
       AWS.mock('ACM', 'listCertificates', certTestData);
 
       const plugin = constructPlugin('', 'does_not_exist', true, true);
+      plugin.acm = new aws.ACM();
 
       return plugin.getCertArn().then(() => {
         throw new Error('Test has failed. getCertArn did not catch errors.');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -383,6 +383,9 @@ describe('Custom Domain Plugin', () => {
 
     it('createDomain', async () => {
       AWS.mock('ACM', 'listCertificates', certTestData);
+      AWS.mock('APIGateway', 'getDomainName', (params, callback) => {
+        callback(new Error('domain doesn\'t exist'), {});
+      });
       AWS.mock('APIGateway', 'createDomainName', (params, callback) => {
         callback(null, { distributionDomainName: 'foo', regionalHostedZoneId: 'test_id' });
       });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,6 +16,8 @@ const testCreds = {
 
 const constructPlugin =
   (basepath, certName, stage, createRecord, endpointType, enabled) => {
+    aws.config.update(testCreds);
+
     const serverless = {
       cli: {
         log(params) { return params; },
@@ -27,6 +29,11 @@ const constructPlugin =
         aws: {
           getCredentials: () => new aws.Credentials(testCreds),
           getRegion: () => 'eu-west-1',
+          sdk: {
+            APIGateway: aws.APIGateway,
+            ACM: aws.ACM,
+            Route53: aws.Route53,
+          },
         },
       },
       service: {


### PR DESCRIPTION
Make use of the SDK inside the serverless object in order to keep options set for that SDK like HTTP proxies or credentials.