### PR TITLE
Provide option to use a different profile for Route53 actions

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,10 +47,21 @@ class ServerlessCustomDomain {
   initializeVariables() {
     if (!this.initialized) {
       // Sets the credentials for AWS resources.
-      const awsCreds = this.serverless.providers.aws.getCredentials();
-      AWS.config.update(awsCreds);
+        let awsCreds = this.serverless.providers.aws.getCredentials();
+        let awsRegion = this.serverless.providers.aws.getRegion();
+        AWS.config.update(awsCreds);
+        const domainProfile = this.serverless.service.custom.customDomain.route53Profile;
+        if (domainProfile) {
+            awsCreds = new AWS.SharedIniFileCredentials({profile: domainProfile});
+            awsRegion = this.serverless.service.custom.customDomain.route53Region || "us-east-1";
+
+        }
+      const options = {
+          region: awsRegion,
+          credentials: awsCreds
+      }
       this.apigateway = new AWS.APIGateway();
-      this.route53 = new AWS.Route53();
+      this.route53 = new AWS.Route53(options);
       this.setGivenDomainName(this.serverless.service.custom.customDomain.domainName);
       this.setEndpointType(this.serverless.service.custom.customDomain.endpointType);
       this.setAcmRegion();

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ class ServerlessCustomDomain {
       const domainProfile = this.serverless.service.custom.customDomain.route53Profile;
       if (domainProfile) {
         awsCreds = new AWS.SharedIniFileCredentials({ profile: domainProfile });
-        awsRegion = this.serverless.service.custom.customDomain.route53Region || 'us-east-1';
+        awsRegion = this.serverless.service.custom.customDomain.route53Region || this.serverless.providers.aws.getRegion() || 'us-east-1';
       }
       const options = {
         region: awsRegion,

--- a/index.js
+++ b/index.js
@@ -47,19 +47,18 @@ class ServerlessCustomDomain {
   initializeVariables() {
     if (!this.initialized) {
       // Sets the credentials for AWS resources.
-        let awsCreds = this.serverless.providers.aws.getCredentials();
-        let awsRegion = this.serverless.providers.aws.getRegion();
-        AWS.config.update(awsCreds);
-        const domainProfile = this.serverless.service.custom.customDomain.route53Profile;
-        if (domainProfile) {
-            awsCreds = new AWS.SharedIniFileCredentials({profile: domainProfile});
-            awsRegion = this.serverless.service.custom.customDomain.route53Region || "us-east-1";
-
-        }
-      const options = {
-          region: awsRegion,
-          credentials: awsCreds
+      let awsCreds = this.serverless.providers.aws.getCredentials();
+      let awsRegion = this.serverless.providers.aws.getRegion();
+      AWS.config.update(awsCreds);
+      const domainProfile = this.serverless.service.custom.customDomain.route53Profile;
+      if (domainProfile) {
+        awsCreds = new AWS.SharedIniFileCredentials({ profile: domainProfile });
+        awsRegion = this.serverless.service.custom.customDomain.route53Region || 'us-east-1';
       }
+      const options = {
+        region: awsRegion,
+        credentials: awsCreds,
+      };
       this.apigateway = new AWS.APIGateway();
       this.route53 = new AWS.Route53(options);
       this.setGivenDomainName(this.serverless.service.custom.customDomain.domainName);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -15,13 +15,12 @@ const testCreds = {
 };
 
 const testRoute53Domain = {
-    route53Profile: 'test-profile',
-    route53Region: 'us-moon-42'
+  route53Profile: 'test-profile',
+  route53Region: 'us-moon-42',
 };
 
 const constructPlugin =
   (basepath, certName, stage, createRecord, endpointType) => {
-
     const serverless = {
       cli: {
         log(params) { return params; },
@@ -52,9 +51,9 @@ const constructPlugin =
             basePath: basepath,
             domainName: 'test_domain',
             endpointType,
-                    }
-        }
-      }
+          },
+        },
+      },
     };
 
     if (certName) {
@@ -86,32 +85,30 @@ describe('Custom Domain Plugin', () => {
     expect(plugin.initialized).to.equal(true);
   });
 
-    it('uses default credentials for route 53', () => {
-        const plugin = constructPlugin({}, 'tests', true, true);
-        expect(plugin.initialized).to.equal(false);
+  it('uses default credentials for route 53', () => {
+    const plugin = constructPlugin({}, 'tests', true, true);
+    expect(plugin.initialized).to.equal(false);
 
-        plugin.initializeVariables();
+    plugin.initializeVariables();
 
-        const returnedCreds = plugin.route53.config.credentials;
+    const returnedCreds = plugin.route53.config.credentials;
 
-        expect(returnedCreds.accessKeyId).to.equal(testCreds.accessKeyId);
-        expect(returnedCreds.secretAccessKey).to.equal(testCreds.secretAccessKey);
-        expect(plugin.initialized).to.equal(true);
-    });
+    expect(returnedCreds.accessKeyId).to.equal(testCreds.accessKeyId);
+    expect(returnedCreds.secretAccessKey).to.equal(testCreds.secretAccessKey);
+    expect(plugin.initialized).to.equal(true);
+  });
 
   it('overrides credentials for route 53', () => {
-      //AWS.mock('SharedIniFileCredentials', 'get', new aws.Credentials(testRoute53Creds));
+    const plugin = constructPlugin({}, 'tests', true, true);
+    Object.assign(plugin.serverless.service.custom.customDomain, testRoute53Domain);
+    expect(plugin.initialized).to.equal(false);
 
-      const plugin = constructPlugin({}, 'tests', true, true);
-      Object.assign(plugin.serverless.service.custom.customDomain , testRoute53Domain);
-      expect(plugin.initialized).to.equal(false);
+    plugin.initializeVariables();
 
-      plugin.initializeVariables();
-
-      const returnedCreds = plugin.route53.config.credentials;
-      expect(returnedCreds.profile).to.equal(testRoute53Domain.route53Profile);
-      expect(plugin.route53.config.region).to.equal(testRoute53Domain.route53Region);
-      expect(plugin.initialized).to.equal(true);
+    const returnedCreds = plugin.route53.config.credentials;
+    expect(returnedCreds.profile).to.equal(testRoute53Domain.route53Profile);
+    expect(plugin.route53.config.region).to.equal(testRoute53Domain.route53Region);
+    expect(plugin.initialized).to.equal(true);
   });
 
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -49,9 +49,9 @@ const constructPlugin =
         },
         custom: {
           customDomain: {
-                      basePath: basepath,
-                      domainName: 'test_domain',
-                      endpointType,
+              basePath: basepath,
+              domainName: 'test_domain',
+              endpointType,
                     }
         }
       }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -49,9 +49,9 @@ const constructPlugin =
         },
         custom: {
           customDomain: {
-              basePath: basepath,
-              domainName: 'test_domain',
-              endpointType,
+            basePath: basepath,
+            domainName: 'test_domain',
+            endpointType,
                     }
         }
       }


### PR DESCRIPTION
Hi there,

We ran into an issue where our API Gateways and Lambda functions are in a different account then our Route53. Specifically, DNS records are owned by a parent account, with sub accounts being used for environments (dev, prod, etc). 

One option would be to delegate subdomains to the different accounts. I prefer to have all the DNS records for the domain in one account though. I suspect others have similar setups, and possibly have setups where different accounts aren't cleanly divided by subdomain.

To that end, this PR adds two additional options to the configuration. 

```
    route53Profile: my-profile
    route53Region: us-east-1
``` 
route53Profile specifies which profile to use from the standard AWS configuration file. 
route53Region specifies the region of the account to use (it will default to us-east-1). 

This configuration is then used on the Route53 DNS calls.

Feedback and comments are always appreciate, and thanks for writing this plugin!
