### PR TITLE
Use configured credentials for all AWS APIs.

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,16 +47,14 @@ class ServerlessCustomDomain {
     if (!this.initialized) {
       this.enabled = this.evaluateEnabled();
       if (this.enabled) {
-        this.apigateway = new this.serverless.providers.aws.sdk.APIGateway({
-          region: this.serverless.providers.aws.getRegion(),
-        });
-        this.route53 = new this.serverless.providers.aws.sdk.Route53();
+        const credentials = this.serverless.providers.aws.getCredentials();
+        this.apigateway = new this.serverless.providers.aws.sdk.APIGateway(credentials);
+        this.route53 = new this.serverless.providers.aws.sdk.Route53(credentials);
         this.setGivenDomainName(this.serverless.service.custom.customDomain.domainName);
         this.setEndpointType(this.serverless.service.custom.customDomain.endpointType);
         this.setAcmRegion();
-        this.acm = new this.serverless.providers.aws.sdk.ACM({
-          region: this.acmRegion,
-        });
+        const acmCredentials = Object.assign({}, credentials, { region: this.acmRegion });
+        this.acm = new this.serverless.providers.aws.sdk.ACM(acmCredentials);
       }
 
       this.initialized = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
This allows non-default credentials (e.g. by specifying `--aws-profile`
with `sls`) to be correctly propagated when using the APIGateway,
Route53 and ACM APIs.