### PR TITLE
Don't add HostedZoneId to outputs if not set

### DIFF
--- a/index.js
+++ b/index.js
@@ -314,9 +314,11 @@ class ServerlessCustomDomain {
     service.provider.compiledCloudFormationTemplate.Outputs.DomainName = {
       Value: data.domainName,
     };
-    service.provider.compiledCloudFormationTemplate.Outputs.HostedZoneId = {
-      Value: data.hostedZoneId,
-    };
+    if (data.hostedZoneId) {
+      service.provider.compiledCloudFormationTemplate.Outputs.HostedZoneId = {
+        Value: data.hostedZoneId,
+      };
+    }
   }
 
   /*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
When not using route53 hostedZoneId isn't set and cause an invalid CloudFormation template to be generated:

```
The CloudFormation template is invalid: Template format error: Every Outputs member must contain a Value object
```

This simple add a check so we don't add the HostedZoneId output if not set.