### PR TITLE
Reverting setupBasePathMapping Hook Change

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ class ServerlessCustomDomain {
     this.hooks = {
       'delete_domain:delete': this.deleteDomain.bind(this),
       'create_domain:create': this.createDomain.bind(this),
-      'after:package:compileEvents': this.setUpBasePathMapping.bind(this),
+      'before:deploy:deploy': this.setUpBasePathMapping.bind(this),
       'after:deploy:deploy': this.domainSummary.bind(this),
       'after:info:info': this.domainSummary.bind(this),
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
This appears to have caused a lot of issues for folks, and there are
some good arguments that the package command should not need to pull
down things from AWS to work, and this is really only needed when we
want to deploy the service.

Please see #52 for more information.