### PR TITLE
Add single quotes to certificateName in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ custom:
     domainName: serverless.foo.com
     stage: ci
     basePath: api
-    certificateName: *.foo.com
+    certificateName: '*.foo.com'
     createRoute53Record: true
     endpointType: 'regional'
 ```


### PR DESCRIPTION
Try and prevent users from running into an `unidentified alias` error when copying the provided examples.

See #105 for an example case.