### PR TITLE
Do not try to use expired/revoked/failed certificates when selecting cert by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.6.6] - 2018-11-07
+
+### Changed
+- Updated certificate selection to only use unexpired certificates.
+
 ## [2.6.5] - 2018-08-27
 
 ### Changed

--- a/index.js
+++ b/index.js
@@ -357,7 +357,7 @@ class ServerlessCustomDomain {
       return Promise.resolve(specificCertificateArn);
     }
 
-    const certArn = this.acm.listCertificates().promise();
+    const certArn = this.acm.listCertificates({CertificateStatuses: ['PENDING_VALIDATION', 'ISSUED', 'INACTIVE']}).promise();
 
     return certArn.catch((err) => {
       throw Error(`Error: Could not list certificates in Certificate Manager.\n${err}`);
@@ -369,6 +369,7 @@ class ServerlessCustomDomain {
       // The certificate name
       let certificateName = this.serverless.service.custom.customDomain.certificateName;
 
+      const certificates = data.CertificateSummaryList
 
       // Checks if a certificate name is given
       if (certificateName != null) {

--- a/index.js
+++ b/index.js
@@ -357,7 +357,7 @@ class ServerlessCustomDomain {
       return Promise.resolve(specificCertificateArn);
     }
 
-    const certArn = this.acm.listCertificates({CertificateStatuses: ['PENDING_VALIDATION', 'ISSUED', 'INACTIVE']}).promise();
+    const certArn = this.acm.listCertificates({ CertificateStatuses: ['PENDING_VALIDATION', 'ISSUED', 'INACTIVE'] }).promise();
 
     return certArn.catch((err) => {
       throw Error(`Error: Could not list certificates in Certificate Manager.\n${err}`);
@@ -369,11 +369,11 @@ class ServerlessCustomDomain {
       // The certificate name
       let certificateName = this.serverless.service.custom.customDomain.certificateName;
 
-      const certificates = data.CertificateSummaryList
+      const certificates = data.CertificateSummaryList;
 
       // Checks if a certificate name is given
       if (certificateName != null) {
-        const foundCertificate = data.CertificateSummaryList
+        const foundCertificate = certificates
           .find(certificate => (certificate.DomainName === certificateName));
 
         if (foundCertificate != null) {
@@ -381,7 +381,7 @@ class ServerlessCustomDomain {
         }
       } else {
         certificateName = this.givenDomainName;
-        data.CertificateSummaryList.forEach((certificate) => {
+        certificates.forEach((certificate) => {
           let certificateListName = certificate.DomainName;
 
           // Looks for wild card and takes it out when checking

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
If you have two domains of the same name, and one is expired, we should pick the unexpired one.