### PR TITLE
Throw explicit error when plugin configuration is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.7.0] - 2018-12-14
+
+### Added
+- Check to ensure plugin configuration exists and throw an error if it does not.
+
+### Changed
+- Updated unit tests.
+
 ## [2.6.7] - 2018-11-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.7.0] - 2018-12-14
+## [2.6.9] - 2018-12-17
 
 ### Added
 - Check to ensure plugin configuration exists and throw an error if it does not.

--- a/index.js
+++ b/index.js
@@ -69,8 +69,13 @@ class ServerlessCustomDomain {
    * If the property's value is undefined, a default value of true is assumed (for backwards
    * compatibility).
    * If the property's value is provided, this should be boolean, otherwise an exception is thrown.
+   * If no customDomain object exists, an exception is thrown.
    */
   evaluateEnabled() {
+    if (typeof this.serverless.service.custom.customDomain === 'undefined') {
+      throw new Error('serverless-domain-manager: Plugin configuration is missing.');
+    }
+
     const enabled = this.serverless.service.custom.customDomain.enabled;
     if (enabled === undefined) {
       return true;

--- a/index.js
+++ b/index.js
@@ -72,7 +72,8 @@ class ServerlessCustomDomain {
    * If no customDomain object exists, an exception is thrown.
    */
   evaluateEnabled() {
-    if (typeof this.serverless.service.custom.customDomain === 'undefined') {
+    if (typeof this.serverless.service.custom === 'undefined'
+      || typeof this.serverless.service.custom.customDomain === 'undefined') {
       throw new Error('serverless-domain-manager: Plugin configuration is missing.');
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.7.0",
+  "version": "2.6.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.6.7",
+  "version": "2.6.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.6.7",
+  "version": "2.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.7.0",
+  "version": "2.6.8",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.6.8",
+  "version": "2.6.9",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.6.8",
+  "version": "2.7.0",
   "engines": {
     "node": ">=4.0"
   },

--- a/test/unit-tests/index.test.js
+++ b/test/unit-tests/index.test.js
@@ -822,4 +822,34 @@ describe('Custom Domain Plugin', () => {
       expect(errored).to.equal(true);
     });
   });
+
+  describe('Missing plugin configuration', () => {
+    it('Should thrown an Error when plugin customDomain configuration object is missing', () => {
+      const plugin = constructPlugin();
+      delete plugin.serverless.service.custom.customDomain;
+
+      let errored = false;
+      try {
+        plugin.initializeVariables();
+      } catch (err) {
+        errored = true;
+        expect(err.message).to.equal('serverless-domain-manager: Plugin configuration is missing.');
+      }
+      expect(errored).to.equal(true);
+    });
+
+    it('Should thrown an Error when Serverless custom configuration object is missing', () => {
+      const plugin = constructPlugin();
+      delete plugin.serverless.service.custom;
+
+      let errored = false;
+      try {
+        plugin.initializeVariables();
+      } catch (err) {
+        errored = true;
+        expect(err.message).to.equal('serverless-domain-manager: Plugin configuration is missing.');
+      }
+      expect(errored).to.equal(true);
+    });
+  });
 });


### PR DESCRIPTION
Hello,

I encountered an issue that surfaces when this plugin is listed in the Serverless `plugins` array but no `custom.customDomain` object is defined: a `Type Error` is thrown with the message `"Cannot read property 'enabled' of undefined"`. This error is thrown because there is no check to ensure that `this.serverless.service.custom.customDomain` exists before setting the `enabled` constant on line 78 of `index.js` (within the `ServerlessCustomDomain.evaluateEnabled()` method. While I would agree that if a plugin is enabled in Serverless it should be properly configured, it would be nice if this plugin handled such a case a little more gracefully.

Therefore, this pull request tweaks the current behavior so that instead of the default `Type Error` being thrown in this situation, it throws an error with the message `'serverless-domain-manager: Plugin configuration is missing.'`