### PR TITLE
Add better domain name matching.  

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.6.11",
+  "version": "2.6.12",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.6.10",
+  "version": "2.6.11",
   "engines": {
     "node": ">=4.0"
   },

--- a/test/unit-tests/index.test.js
+++ b/test/unit-tests/index.test.js
@@ -616,6 +616,24 @@ describe('Custom Domain Plugin', () => {
       expect(result).to.equal('test_id_0');
     });
 
+    it('Sub domain name - non domain matching prefix', async () => {
+      AWS.mock('Route53', 'listHostedZones', (params, callback) => {
+        callback(null, {
+          HostedZones: [
+            { Name: 'aaaa.com.', Id: '/hostedzone/test_id_2', Config: { PrivateZone: false } },
+            { Name: 'aaa.com.', Id: '/hostedzone/test_id_1', Config: { PrivateZone: false } },
+            { Name: 'bbb.aaa.com.', Id: '/hostedzone/test_id_0', Config: { PrivateZone: false } }],
+        });
+      });
+
+      const plugin = constructPlugin(null, null, null);
+      plugin.route53 = new aws.Route53();
+      plugin.setGivenDomainName('ccc-bbb.aaa.com');
+
+      const result = await plugin.getRoute53HostedZoneId();
+      expect(result).to.equal('test_id_1');
+    });
+
     afterEach(() => {
       AWS.restore();
     });


### PR DESCRIPTION
Hi,
I've added a different domain name to hosted zone matching algorithm.  Instead of using the longest matching string it now breaks the domains into its parts and matches those. So:

ccc-bbb.aaa.com no longer matches zone bbb.aaa.com