### PR TITLE
Use existing API id only when defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -314,7 +314,7 @@ class ServerlessCustomDomain {
     let apiGatewayRef = { Ref: 'ApiGatewayRestApi' };
 
     // If user has specified an existing API Gateway API, then attach to that
-    if (service.provider.apiGateway) {
+    if (service.provider.apiGateway && service.provider.apiGateway.restApiId) {
       this.serverless.cli.log(`Mapping custom domain to existing API ${service.provider.apiGateway.restApiId}.`);
       apiGatewayRef = service.provider.apiGateway.restApiId;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.6.9",
+  "version": "2.6.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.6.10",
+  "version": "2.6.11",
   "engines": {
     "node": ">=4.0"
   },

--- a/test/unit-tests/index.test.js
+++ b/test/unit-tests/index.test.js
@@ -163,6 +163,24 @@ describe('Custom Domain Plugin', () => {
       const cf = noStagePlugin.serverless.service.provider.compiledCloudFormationTemplate.Resources;
       expect(cf.pathmapping.Properties.Stage).to.equal('providerStage');
     });
+
+    it('references the id of the API being created', () => {
+      plugin.addResources(deploymentId);
+      const cf = plugin.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources;
+      expect(cf.pathmapping.Properties.RestApiId).to.deep.equal({ Ref: 'ApiGatewayRestApi' });
+    });
+
+    it('uses existing API id when defined in provider data', () => {
+      const apiIdExistingPlugin = constructPlugin('test_basepath', null, true, true);
+      apiIdExistingPlugin.serverless.service.provider.apiGateway = {
+        restApiId: 'some-id',
+      };
+      apiIdExistingPlugin.addResources(deploymentId);
+      const cf = apiIdExistingPlugin.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources;
+      expect(cf.pathmapping.Properties.RestApiId).to.equal('some-id');
+    });
   });
 
   describe('Create a New Domain Name', () => {


### PR DESCRIPTION
This fixes a bug where having any custom data defined in provider data
will trigger a ValidationError because the existing API id is null
or undefined.

A typical use case is when provider data contains API key definitions and the plugin cannot deploy new stages anymore. Existing stages will still work though.

```yaml
provider:
  name: aws
  runtime: ${opt:runtime, 'nodejs8.10'}
  stage: ${opt:stage}
  region: eu-west-1
  apiGateway:
    apiKeySourceType: HEADER
# [...]
```

This fixes https://github.com/amplify-education/serverless-domain-manager/issues/177