### PR TITLE
Integration Tests for custom API Gateway field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.6.13] - 2019-01-25
+
+### Added
+- Created integration test for custom API field being set.
+
+
+## [2.6.12] - 2019-01-18
+
+### Changed
+- Implemented a better hosted zone matching algorithm to break domain into parts.
+
+
+## [2.6.11] - 2019-01-10
+
+### Changed
+- Fixes bug where having any custom data defined in provider data will trigger a ValidationError because the existing API id is null or undefined.
+
+
 ## [2.6.10] - 2018-12-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.6.10",
+  "version": "2.6.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.6.12",
+  "version": "2.6.13",
   "engines": {
     "node": ">=4.0"
   },

--- a/test/integration-tests/enabled-custom-apigateway/handler.js
+++ b/test/integration-tests/enabled-custom-apigateway/handler.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports.helloWorld = (event, context, callback) => {
+  const response = {
+    statusCode: 200,
+    headers: {
+      'Access-Control-Allow-Origin': '*', // Required for CORS support to work
+    },
+    body: JSON.stringify({
+      message: 'Go Serverless v1.0! Your function executed successfully!',
+      input: event,
+    }),
+  };
+
+  callback(null, response);
+};

--- a/test/integration-tests/enabled-custom-apigateway/serverless.yml
+++ b/test/integration-tests/enabled-custom-apigateway/serverless.yml
@@ -1,0 +1,23 @@
+# Enabled with default values
+service: enabled-custom-apigateway
+provider:
+  name: aws
+  runtime: nodejs6.10
+  region: us-west-2
+  apiGateway:
+    restApiId: ${env:REST_API_ID}
+    restApiResources:
+      'hello-world': ${env:RESOURCE_ID}
+functions:
+  helloWorld:
+    handler: handler.helloWorld
+    events:
+      - http:
+          path: hello-world
+          method: get
+          cors: true
+plugins:
+  - serverless-domain-manager
+custom:
+  customDomain:
+    domainName: enabled-custom-apigateway-${opt:RANDOM_STRING}.${env:TEST_DOMAIN}

--- a/test/integration-tests/integration.test.js
+++ b/test/integration-tests/integration.test.js
@@ -4,7 +4,6 @@ const chai = require('chai');
 const itParam = require('mocha-param');
 const utilities = require('./test-utilities');
 const randomstring = require('randomstring');
-const dns = require('dns');
 
 const expect = chai.expect;
 

--- a/test/integration-tests/integration.test.js
+++ b/test/integration-tests/integration.test.js
@@ -4,6 +4,7 @@ const chai = require('chai');
 const itParam = require('mocha-param');
 const utilities = require('./test-utilities');
 const randomstring = require('randomstring');
+const dns = require('dns');
 
 const expect = chai.expect;
 
@@ -24,6 +25,16 @@ const testCases = [
     testBasePath: '(none)',
     testEndpoint: 'EDGE',
     testURL: `https://enabled-default-${RANDOM_STRING}.${TEST_DOMAIN}/hello-world`,
+  },
+  {
+    testDescription: 'Enabled with custom api gateway',
+    testFolder: 'enabled-custom-apigateway',
+    testDomain: `enabled-custom-apigateway-${RANDOM_STRING}.${TEST_DOMAIN}`,
+    testStage: 'dev',
+    testBasePath: '(none)',
+    testEndpoint: 'EDGE',
+    testURL: `https://enabled-custom-apigateway-${RANDOM_STRING}.${TEST_DOMAIN}`,
+    createApiGateway: true,
   },
   {
     testDescription: 'Enabled with custom basepath',
@@ -84,6 +95,10 @@ describe('Integration Tests', function () { // eslint-disable-line func-names
     this.timeout(SIX_HOURS);
 
     itParam('${value.testDescription}', testCases, async (value) => { // eslint-disable-line no-template-curly-in-string
+      let restApiInfo;
+      if (value.createApiGateway) {
+        restApiInfo = await utilities.setupApiGatewayResources(RANDOM_STRING);
+      }
       const created = await utilities.createResources(value.testFolder,
           value.testDomain, RANDOM_STRING, true);
       if (!created) {
@@ -102,6 +117,9 @@ describe('Integration Tests', function () { // eslint-disable-line func-names
         expect(status).to.equal(200);
       }
       await utilities.destroyResources(value.testFolder, value.testDomain, RANDOM_STRING);
+      if (value.createApiGateway) {
+        await utilities.deleteApiGatewayResources(restApiInfo.restApiId);
+      }
     });
   });
 

--- a/test/integration-tests/test-utilities.js
+++ b/test/integration-tests/test-utilities.js
@@ -284,6 +284,30 @@ async function destroyResources(folderName, url, domainIdentifier) {
   return removed;
 }
 
+/**
+ * Make API Gateway calls to create an API Gateway
+ * @param {string} randString
+ * @return {Object} Contains restApiId and resourceId
+ */
+async function setupApiGatewayResources(randString) {
+  const restApiInfo = await apiGateway.createRestApi({ name: `rest-api-${randString}` }).promise();
+  const restApiId = restApiInfo.id;
+  const resourceInfo = await apiGateway.getResources({ restApiId }).promise();
+  const resourceId = resourceInfo.items[0].id;
+  shell.env['REST_API_ID'] = restApiId;
+  shell.env['RESOURCE_ID'] = resourceId;
+  return {restApiId, resourceId};
+}
+
+/**
+ * Make API Gateway calls to delete an API Gateway
+ * @param {string} restApiId
+ * @return {boolean} Returns true if deleted
+ */
+async function deleteApiGatewayResources(restApiId) {
+  return await apiGateway.deleteRestApi({ restApiId }).promise();
+}
+
 module.exports = {
   curlUrl,
   createResources,
@@ -302,4 +326,6 @@ module.exports = {
   linkPackages,
   sleep,
   CreationError,
+  setupApiGatewayResources,
+  deleteApiGatewayResources,
 };

--- a/test/integration-tests/test-utilities.js
+++ b/test/integration-tests/test-utilities.js
@@ -290,12 +290,12 @@ async function destroyResources(folderName, url, domainIdentifier) {
  * @return {Object} Contains restApiId and resourceId
  */
 async function setupApiGatewayResources(randString) {
-  const restApiInfo = await apiGateway.createRestApi({ name: `rest-api-${randString}` }).promise();
+  const restApiInfo = await apiGateway.createRestApi( { name: `rest-api-${randString}` } ).promise();
   const restApiId = restApiInfo.id;
-  const resourceInfo = await apiGateway.getResources({ restApiId }).promise();
+  const resourceInfo = await apiGateway.getResources( { restApiId } ).promise();
   const resourceId = resourceInfo.items[0].id;
-  shell.env['REST_API_ID'] = restApiId;
-  shell.env['RESOURCE_ID'] = resourceId;
+  shell.env.REST_API_ID = restApiId;
+  shell.env.RESOURCE_ID = resourceId;
   return {restApiId, resourceId};
 }
 
@@ -305,7 +305,7 @@ async function setupApiGatewayResources(randString) {
  * @return {boolean} Returns true if deleted
  */
 async function deleteApiGatewayResources(restApiId) {
-  return await apiGateway.deleteRestApi({ restApiId }).promise();
+  return apiGateway.deleteRestApi({ restApiId }).promise();
 }
 
 module.exports = {

--- a/test/integration-tests/test-utilities.js
+++ b/test/integration-tests/test-utilities.js
@@ -290,13 +290,13 @@ async function destroyResources(folderName, url, domainIdentifier) {
  * @return {Object} Contains restApiId and resourceId
  */
 async function setupApiGatewayResources(randString) {
-  const restApiInfo = await apiGateway.createRestApi( { name: `rest-api-${randString}` } ).promise();
+  const restApiInfo = await apiGateway.createRestApi({ name: `rest-api-${randString}` }).promise();
   const restApiId = restApiInfo.id;
-  const resourceInfo = await apiGateway.getResources( { restApiId } ).promise();
+  const resourceInfo = await apiGateway.getResources({ restApiId }).promise();
   const resourceId = resourceInfo.items[0].id;
   shell.env.REST_API_ID = restApiId;
   shell.env.RESOURCE_ID = resourceId;
-  return {restApiId, resourceId};
+  return { restApiId, resourceId };
 }
 
 /**


### PR DESCRIPTION
Fetches `restApiId` and `resourceId` of a created REST API and passes them as env vars to `serverless.yml`'s custom API Gateway field.