### PR TITLE
Update Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [3.0.0] - 2019-01-24
+## [3.0.1] - 2019-02-04
+- Version bump to fix NPM versioning issue that occured while testing.
+
+## [3.0.0] - 2019-02-04
 
 ### Changed
 - Refactored from Javascript into Typescript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
When testing, uploaded `3.0.0` as a beta release. Unable to deploy the same version to NPM, so `3.0.1` it is.