### PR TITLE
Refactor Rollout Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_deploy:
 - npm run build
 deploy:
   skip_cleanup: true
+  tag: beta
   provider: npm
   email: $NPM_EMAIL
   api_key: $NPM_KEY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Fixed issue where creating a domain was no longer idempotent in 3.0.4
+- Fixed issue where deploying was no longer idempotent in 3.0.4 due to basepath mapping creation
+- Fixed issue where deploying would break on occasion if more than 100 CloudFormation resources existed
+
 ## [3.0.2 - 3.0.4] - 2019-02-06
 - Fix Travis configuration
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ To remove the created custom domain:
 serverless delete_domain
 ```
 # How it works
-Creating the custom domain takes advantage of Amazon's Certificate Manager to assign a certificate to the given domain name. Based on already created certificate names, the plugin will search for the certificate that resembles the custom domain's name the most and assign the ARN to that domain name. The plugin then creates the proper A Alias records for the domain through Route 53. Once the domain name is set it takes up to 40 minutes before it is initialized. After the certificate is initialized, `sls deploy` will create the base path mapping and assign the lambda to the custom domain name through CloudFront. All resources are created independent of CloudFormation.
+Creating the custom domain takes advantage of Amazon's Certificate Manager to assign a certificate to the given domain name. Based on already created certificate names, the plugin will search for the certificate that resembles the custom domain's name the most and assign the ARN to that domain name. The plugin then creates the proper A Alias records for the domain through Route 53. Once the domain name is set it takes up to 40 minutes before it is initialized. After the certificate is initialized, `sls deploy` will create the base path mapping and assign the lambda to the custom domain name through CloudFront. All resources are created independent of CloudFormation. However, deploying will also output the domain name and distribution domain name to the CloudFormation stack outputs under the keys `DomainName` and `DistributionDomainName`, respectively.
 
 Note: In 1.0, we only created CNAME records. In 2.0 we deprecated CNAME creation and started creating A Alias records and migrated CNAME records to A Alias records. Now in 3.0, we only create A Alias records.
 
@@ -129,6 +129,7 @@ Unit tests are found in `test/unit-tests`. Integration tests are found in `test/
 * (5/23/2017) CloudFormation does not support changing the base path from empty to something or vice a versa. You must run `sls remove` to remove the base path mapping.
 * (1/17/2018) The `create_domain` command provided by this plugin does not currently update an existing Custom Domain's configuration. Instead, it only supports updating the Route 53 record pointing to the Custom Domain. For example, one must delete and recreate a Custom Domain to migrate it from regional to edge or vice versa, or to modify the certificate.
 * (8/22/2018) Creating a custom domain creates a CloudFront Distribution behind the scenes for fronting your API Gateway. This CloudFront Distribution is managed by AWS and cannot be viewed/managed by you. This is not a bug, but a quirk of how the Custom Domain feature works in API Gateway.
+* (2/12/2019) Users who upgraded from 2.x.x to version 3.0.4 (now unpublished) and then reverted back to 2.x.x will be unable to deploy because of a bug that will be fixed in 3.1.0. The workaround is to delete the basepath mapping manually, which will let them successfully revert back to 2.x.x.
 
 # Responsible Disclosure
 If you have any security issue to report, contact project maintainers privately.

--- a/index.ts
+++ b/index.ts
@@ -96,7 +96,7 @@ class ServerlessCustomDomain {
             await this.changeResourceRecordSet("UPSERT", domainInfo);
             this.serverless.cli.log(
                 `Custom domain ${this.givenDomainName} was created.
-                New domains may take up to 40 minutes to be initialized.`,
+            New domains may take up to 40 minutes to be initialized.`,
             );
         } else {
             this.serverless.cli.log(`Custom domain ${this.givenDomainName} already exists.`);

--- a/index.ts
+++ b/index.ts
@@ -552,7 +552,7 @@ class ServerlessCustomDomain {
             await this.apigateway.deleteBasePathMapping(params).promise();
             this.serverless.cli.log("Removed basepath mapping.");
         } catch (err) {
-            throw new Error(`Error: Unable to delete basepath mapping.\n`);
+            this.serverless.cli.log("Unable to remove basepath mapping.");
         }
     }
 

--- a/index.ts
+++ b/index.ts
@@ -523,7 +523,7 @@ class ServerlessCustomDomain {
         } catch (err) {
             throw new Error(`Error: Failed to find CloudFormation resources for ${this.givenDomainName}\n`);
         }
-        let restApiId = response.StackResourceDetail.PhysicalResourceId;
+        const restApiId = response.StackResourceDetail.PhysicalResourceId;
         if (!restApiId) {
             throw new Error(`Error: No RestApiId associated with CloudFormation stack ${stackName}`);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "3.0.4",
+  "version": "3.1.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2564,15 +2564,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
       "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
       "dev": true
-    },
-    "serverless-domain-manager": {
-      "version": "file:",
-      "dev": true,
-      "requires": {
-        "@types/chai-spies": "^1.0.0",
-        "aws-sdk": "^2.177.0",
-        "chalk": "^2.4.1"
-      }
     },
     "shelljs": {
       "version": "0.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "3.0.0",
+  "version": "3.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "3.0.4",
+  "version": "3.1.0-beta.0",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "randomstring": "^1.1.5",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.5",
-    "serverless-domain-manager": ".",
     "shelljs": "^0.8.3",
     "ts-node": "^8.0.1",
     "tslint": "^5.1.0",

--- a/test/integration-tests/create-domain-idempotent/handler.js
+++ b/test/integration-tests/create-domain-idempotent/handler.js
@@ -1,0 +1,16 @@
+"use strict";
+
+module.exports.helloWorld = (event, context, callback) => {
+  const response = {
+    statusCode: 200,
+    headers: {
+      "Access-Control-Allow-Origin": "*", // Required for CORS support to work
+    },
+    body: JSON.stringify({
+      message: "Go Serverless v1.0! Your function executed successfully!",
+      input: event,
+    }),
+  };
+
+  callback(null, response);
+};

--- a/test/integration-tests/create-domain-idempotent/serverless.yml
+++ b/test/integration-tests/create-domain-idempotent/serverless.yml
@@ -1,0 +1,21 @@
+# Creating a domain should be idempotent
+service: create-domain-idempotent
+provider:
+  name: aws
+  runtime: nodejs6.10
+  region: us-west-2
+  stage: test
+functions:
+  helloWorld:
+    handler: handler.helloWorld
+    events:
+      - http:
+          path: hello-world
+          method: get
+          cors: true
+plugins:
+  - serverless-domain-manager
+custom:
+  customDomain:
+    domainName: create-domain-idempotent-${opt:RANDOM_STRING}.${env:TEST_DOMAIN}
+    basePath: ''

--- a/test/integration-tests/deploy-idempotent/handler.js
+++ b/test/integration-tests/deploy-idempotent/handler.js
@@ -1,0 +1,16 @@
+"use strict";
+
+module.exports.helloWorld = (event, context, callback) => {
+  const response = {
+    statusCode: 200,
+    headers: {
+      "Access-Control-Allow-Origin": "*", // Required for CORS support to work
+    },
+    body: JSON.stringify({
+      message: "Go Serverless v1.0! Your function executed successfully!",
+      input: event,
+    }),
+  };
+
+  callback(null, response);
+};

--- a/test/integration-tests/deploy-idempotent/serverless.yml
+++ b/test/integration-tests/deploy-idempotent/serverless.yml
@@ -1,0 +1,21 @@
+# Deploying should be idempotent
+service: deploy-idempotent
+provider:
+  name: aws
+  runtime: nodejs6.10
+  region: us-west-2
+  stage: test
+functions:
+  helloWorld:
+    handler: handler.helloWorld
+    events:
+      - http:
+          path: hello-world
+          method: get
+          cors: true
+plugins:
+  - serverless-domain-manager
+custom:
+  customDomain:
+    domainName: deploy-idempotent-${opt:RANDOM_STRING}.${env:TEST_DOMAIN}
+    basePath: ''

--- a/test/integration-tests/integration.test.js
+++ b/test/integration-tests/integration.test.js
@@ -240,17 +240,17 @@ describe("Integration Tests", function () { // eslint-disable-line func-names
     const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
 
     it("Creates a domain multiple times without failure", async () => {
-      let createDomain = true;
+      let createDomainSuccess = true;
       let deploySuccess;
       await utilities.createTempDir(TEMP_DIR, testName);
-      createDomain = createDomain && await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
+      createDomainSuccess = createDomainSuccess && await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      createDomain = createDomain && await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
+      createDomainSuccess = createDomainSuccess && await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      createDomain = createDomain && await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
+      createDomainSuccess = createDomainSuccess && await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
       deploySuccess = await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
-      expect(createDomain).to.equal(true);
+      expect(createDomainSuccess).to.equal(true);
       expect(deploySuccess).to.equal(true);
     });
 
@@ -265,17 +265,17 @@ describe("Integration Tests", function () { // eslint-disable-line func-names
     const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
 
     it("Deploys multiple times without failure", async () => {
-      let createDomain;
+      let createDomainSuccess;
       let deploySuccess = true;
       await utilities.createTempDir(TEMP_DIR, testName);
-      createDomain = await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
+      createDomainSuccess = await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
       deploySuccess = deploySuccess && await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
       deploySuccess = deploySuccess && await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
       deploySuccess = deploySuccess && await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
-      expect(createDomain).to.equal(true);
+      expect(createDomainSuccess).to.equal(true);
       expect(deploySuccess).to.equal(true);
     });
 

--- a/test/integration-tests/integration.test.js
+++ b/test/integration-tests/integration.test.js
@@ -112,7 +112,7 @@ describe("Integration Tests", function () { // eslint-disable-line func-names
         const status = await utilities.curlUrl(value.testURL);
         expect(status).to.equal(200);
       }
-      await utilities.destroyResources(value.testFolder, value.testDomain, RANDOM_STRING);
+      await utilities.destroyResources(value.testDomain, RANDOM_STRING);
       if (value.createApiGateway) {
         await utilities.deleteApiGatewayResources(restApiInfo.restApiId);
       }
@@ -137,7 +137,7 @@ describe("Integration Tests", function () { // eslint-disable-line func-names
     });
 
     after(async () => {
-      await utilities.destroyResources(testName, testURL, RANDOM_STRING);
+      await utilities.destroyResources(testURL, RANDOM_STRING);
     });
   });
 
@@ -149,15 +149,16 @@ describe("Integration Tests", function () { // eslint-disable-line func-names
     before(async () => {
       // Perform sequence of commands to replicate basepath mapping issue
       // Sleep for a min b/w commands in order to avoid rate limiting.
-      await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      await utilities.createTempDir(TEMP_DIR, testName);
+      await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      await utilities.slsDeploy(testName, RANDOM_STRING);
+      await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      await utilities.slsDeleteDomain(testName, RANDOM_STRING);
+      await utilities.slsDeleteDomain(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      await utilities.slsDeploy(testName, RANDOM_STRING);
+      await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
     });
 
     it("Creates a basepath mapping", async () => {
@@ -166,7 +167,7 @@ describe("Integration Tests", function () { // eslint-disable-line func-names
     });
 
     after(async () => {
-      await utilities.destroyResources(testName, testURL, RANDOM_STRING);
+      await utilities.destroyResources(testURL, RANDOM_STRING);
     });
   });
 
@@ -178,15 +179,16 @@ describe("Integration Tests", function () { // eslint-disable-line func-names
     before(async () => {
       // Perform sequence of commands to replicate basepath mapping issue
       // Sleep for a min b/w commands in order to avoid rate limiting.
-      await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      await utilities.createTempDir(TEMP_DIR, testName);
+      await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      await utilities.slsDeploy(testName, RANDOM_STRING);
+      await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      await utilities.slsDeleteDomain(testName, RANDOM_STRING);
+      await utilities.slsDeleteDomain(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      await utilities.slsDeploy(testName, RANDOM_STRING);
+      await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
     });
 
     it("Creates a basepath mapping", async () => {
@@ -195,7 +197,7 @@ describe("Integration Tests", function () { // eslint-disable-line func-names
     });
 
     after(async () => {
-      await utilities.destroyResources(testName, testURL, RANDOM_STRING);
+      await utilities.destroyResources(testURL, RANDOM_STRING);
     });
   });
 
@@ -208,17 +210,18 @@ describe("Integration Tests", function () { // eslint-disable-line func-names
     before(async () => {
       // Perform sequence of commands to replicate basepath mapping issue
       // Sleep for a min b/w commands in order to avoid rate limiting.
-      await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      await utilities.createTempDir(TEMP_DIR, testName);
+      await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      await utilities.slsDeploy(testName, RANDOM_STRING);
+      await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      await utilities.slsDeleteDomain(testName, RANDOM_STRING);
+      await utilities.slsDeleteDomain(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      await utilities.slsRemove(testName, RANDOM_STRING);
+      await utilities.slsRemove(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      await utilities.slsDeploy(testName, RANDOM_STRING);
+      await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
     });
 
     it("Creates a basepath mapping", async () => {
@@ -227,7 +230,7 @@ describe("Integration Tests", function () { // eslint-disable-line func-names
     });
 
     after(async () => {
-      await utilities.destroyResources(testName, testURL, RANDOM_STRING);
+      await utilities.destroyResources(testURL, RANDOM_STRING);
     });
   });
 
@@ -239,19 +242,20 @@ describe("Integration Tests", function () { // eslint-disable-line func-names
     it("Creates a domain multiple times without failure", async () => {
       let createDomain = true;
       let deploySuccess;
-      createDomain = createDomain && await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      await utilities.createTempDir(TEMP_DIR, testName);
+      createDomain = createDomain && await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      createDomain = createDomain && await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      createDomain = createDomain && await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      createDomain = createDomain && await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      createDomain = createDomain && await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      deploySuccess = await utilities.slsDeploy(testName, RANDOM_STRING);
+      deploySuccess = await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
       expect(createDomain).to.equal(true);
       expect(deploySuccess).to.equal(true);
     });
 
     after(async () => {
-      await utilities.destroyResources(testName, testURL, RANDOM_STRING);
+      await utilities.destroyResources(testURL, RANDOM_STRING);
     });
   });
 
@@ -263,56 +267,52 @@ describe("Integration Tests", function () { // eslint-disable-line func-names
     it("Deploys multiple times without failure", async () => {
       let createDomain;
       let deploySuccess = true;
-      createDomain = await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      await utilities.createTempDir(TEMP_DIR, testName);
+      createDomain = await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      deploySuccess = deploySuccess && await utilities.slsDeploy(testName, RANDOM_STRING);
+      deploySuccess = deploySuccess && await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      deploySuccess = deploySuccess && await utilities.slsDeploy(testName, RANDOM_STRING);
+      deploySuccess = deploySuccess && await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
       await utilities.sleep(60);
-      deploySuccess = deploySuccess && await utilities.slsDeploy(testName, RANDOM_STRING);
+      deploySuccess = deploySuccess && await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
       expect(createDomain).to.equal(true);
       expect(deploySuccess).to.equal(true);
     });
 
     after(async () => {
-      await utilities.destroyResources(testName, testURL, RANDOM_STRING);
+      await utilities.destroyResources(testURL, RANDOM_STRING);
     });
   });
 
   describe("Migrating from 2.x.x to 3.x.x works", function () { // eslint-disable-line func-names
     this.timeout(15 * 60 * 1000); // 15 minutes in milliseconds
     const testName = "two-three-migration-default";
-    const tempDir = "~/tmp/domain-manager-test"
     const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
 
     before(async () => {
-      // Perform sequence of commands to replicate basepath mapping issue
-      // Sleep for a min b/w commands in order to avoid rate limiting.
-      await utilities.exec(`rm -rf ${tempDir}`);
-      await utilities.exec(`mkdir -p ${tempDir} && cp -R test/integration-tests/${testName}/. ${tempDir}`);
-      await utilities.exec(`cd ${tempDir}/ && npm install serverless-domain-manager@2.6.13`);
+      await utilities.exec(`rm -rf ${TEMP_DIR}`);
+      await utilities.exec(`mkdir -p ${TEMP_DIR} && cp -R test/integration-tests/${testName}/. ${TEMP_DIR}`);
+      await utilities.exec(`cd ${TEMP_DIR}/ && npm install serverless-domain-manager@2.6.13`);
     });
 
     it("Creates a basepath mapping", async () => {
-      await utilities.exec(`cd ${tempDir} && sls create_domain --RANDOM_STRING ${RANDOM_STRING}`);
+      await utilities.exec(`cd ${TEMP_DIR} && sls create_domain --RANDOM_STRING ${RANDOM_STRING}`);
       await utilities.sleep(60);
-      await utilities.exec(`cd ${tempDir} && sls deploy --RANDOM_STRING ${RANDOM_STRING}`);
+      await utilities.exec(`cd ${TEMP_DIR} && sls deploy --RANDOM_STRING ${RANDOM_STRING}`);
       await utilities.sleep(60);
-      // await utilities.exec(`npm link`)
-      await utilities.exec(`cp -R . ${tempDir}/node_modules/serverless-domain-manager`);
-      await utilities.exec(`cd ${tempDir} && sls deploy --RANDOM_STRING ${RANDOM_STRING}`);
+      await utilities.exec(`cp -R . ${TEMP_DIR}/node_modules/serverless-domain-manager`);
+      await utilities.exec(`cd ${TEMP_DIR} && sls deploy --RANDOM_STRING ${RANDOM_STRING}`);
 
       const basePath = await utilities.getBasePath(testURL);
       expect(basePath).to.equal("(none)");
     });
 
     after(async () => {
-      // await utilities.exec(`npm unlink`);
-      await utilities.exec(`cd ${tempDir} && sls remove --RANDOM_STRING ${RANDOM_STRING}`);
+      await utilities.exec(`cd ${TEMP_DIR} && sls remove --RANDOM_STRING ${RANDOM_STRING}`);
       await utilities.sleep(60);
-      await utilities.exec(`cd ${tempDir} && sls delete_domain --RANDOM_STRING ${RANDOM_STRING}`);
+      await utilities.exec(`cd ${TEMP_DIR} && sls delete_domain --RANDOM_STRING ${RANDOM_STRING}`);
       await utilities.sleep(60);
-      await utilities.exec(`rm -rf ${tempDir}`);
+      await utilities.exec(`rm -rf ${TEMP_DIR}`);
     });
   });
 });

--- a/test/integration-tests/integration.test.js
+++ b/test/integration-tests/integration.test.js
@@ -86,57 +86,167 @@ const testCases = [
 describe("Integration Tests", function () { // eslint-disable-line func-names
   this.timeout(SIX_HOURS); // 6 hours to allow for dns to propogate
 
-  before(async () => {
-    await utilities.linkPackages();
-  });
+  // describe("Domain Manager Is Enabled", function () { // eslint-disable-line func-names
+  //   this.timeout(SIX_HOURS);
 
-  describe("Domain Manager Is Enabled", function () { // eslint-disable-line func-names
-    this.timeout(SIX_HOURS);
+  //   itParam("${value.testDescription}", testCases, async (value) => { // eslint-disable-line no-template-curly-in-string
+  //     let restApiInfo;
+  //     if (value.createApiGateway) {
+  //       restApiInfo = await utilities.setupApiGatewayResources(RANDOM_STRING);
+  //     }
+  //     const created = await utilities.createResources(value.testFolder,
+  //         value.testDomain, RANDOM_STRING, true);
+  //     if (!created) {
+  //       throw new utilities.CreationError("Resources failed to create.");
+  //     } else {
+  //       const stage = await utilities.getStage(value.testDomain);
+  //       expect(stage).to.equal(value.testStage);
 
-    itParam("${value.testDescription}", testCases, async (value) => { // eslint-disable-line no-template-curly-in-string
-      let restApiInfo;
-      if (value.createApiGateway) {
-        restApiInfo = await utilities.setupApiGatewayResources(RANDOM_STRING);
-      }
-      const created = await utilities.createResources(value.testFolder,
-          value.testDomain, RANDOM_STRING, true);
-      if (!created) {
-        throw new utilities.CreationError("Resources failed to create.");
-      } else {
-        const stage = await utilities.getStage(value.testDomain);
-        expect(stage).to.equal(value.testStage);
+  //       const basePath = await utilities.getBasePath(value.testDomain);
+  //       expect(basePath).to.equal(value.testBasePath);
 
-        const basePath = await utilities.getBasePath(value.testDomain);
-        expect(basePath).to.equal(value.testBasePath);
+  //       const endpoint = await utilities.getEndpointType(value.testDomain);
+  //       expect(endpoint).to.equal(value.testEndpoint);
 
-        const endpoint = await utilities.getEndpointType(value.testDomain);
-        expect(endpoint).to.equal(value.testEndpoint);
+  //       const status = await utilities.curlUrl(value.testURL);
+  //       expect(status).to.equal(200);
+  //     }
+  //     await utilities.destroyResources(value.testFolder, value.testDomain, RANDOM_STRING);
+  //     if (value.createApiGateway) {
+  //       await utilities.deleteApiGatewayResources(restApiInfo.restApiId);
+  //     }
+  //   });
+  // });
 
-        const status = await utilities.curlUrl(value.testURL);
-        expect(status).to.equal(200);
-      }
-      await utilities.destroyResources(value.testFolder, value.testDomain, RANDOM_STRING);
-      if (value.createApiGateway) {
-        await utilities.deleteApiGatewayResources(restApiInfo.restApiId);
-      }
-    });
-  });
+  // describe("Domain Manager Is Not Enabled", function () { // eslint-disable-line func-names
+  //   this.timeout(5 * 60 * 1000); // 5 minutes in milliseconds
+  //   const testName = "disabled";
+  //   const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
 
-  describe("Domain Manager Is Not Enabled", function () { // eslint-disable-line func-names
-    this.timeout(5 * 60 * 1000); // 5 minutes in milliseconds
-    const testName = "disabled";
+  //   before(async () => {
+  //     const created = await utilities.createResources(testName, testURL, RANDOM_STRING, false);
+  //     if (!created) {
+  //       throw new utilities.CreationError("Resources failed to create.");
+  //     }
+  //   });
+
+  //   it("Does not create a domain", async () => {
+  //     const data = await utilities.curlUrl(`https://${testURL}/hello-world`);
+  //     expect(data).to.equal(null);
+  //   });
+
+  //   after(async () => {
+  //     await utilities.destroyResources(testName, testURL, RANDOM_STRING);
+  //   });
+  // });
+
+  // describe("Basepath Mapping Is Empty", function () { // eslint-disable-line func-names
+  //   this.timeout(15 * 60 * 1000); // 15 minutes in milliseconds
+  //   const testName = "null-basepath-mapping";
+  //   const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
+
+  //   before(async () => {
+  //     // Perform sequence of commands to replicate basepath mapping issue
+  //     // Sleep for a min b/w commands in order to avoid rate limiting.
+  //     await utilities.slsCreateDomain(testName, RANDOM_STRING);
+  //     await utilities.sleep(60);
+  //     await utilities.slsDeploy(testName, RANDOM_STRING);
+  //     await utilities.sleep(60);
+  //     await utilities.slsDeleteDomain(testName, RANDOM_STRING);
+  //     await utilities.sleep(60);
+  //     await utilities.slsCreateDomain(testName, RANDOM_STRING);
+  //     await utilities.sleep(60);
+  //     await utilities.slsDeploy(testName, RANDOM_STRING);
+  //   });
+
+  //   it("Creates a basepath mapping", async () => {
+  //     const basePath = await utilities.getBasePath(testURL);
+  //     expect(basePath).to.equal("(none)");
+  //   });
+
+  //   after(async () => {
+  //     await utilities.destroyResources(testName, testURL, RANDOM_STRING);
+  //   });
+  // });
+
+  // describe("Basepath Mapping Is Set", function () { // eslint-disable-line func-names
+  //   this.timeout(15 * 60 * 1000); // 15 minutes in milliseconds
+  //   const testName = "basepath-mapping";
+  //   const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
+
+  //   before(async () => {
+  //     // Perform sequence of commands to replicate basepath mapping issue
+  //     // Sleep for a min b/w commands in order to avoid rate limiting.
+  //     await utilities.slsCreateDomain(testName, RANDOM_STRING);
+  //     await utilities.sleep(60);
+  //     await utilities.slsDeploy(testName, RANDOM_STRING);
+  //     await utilities.sleep(60);
+  //     await utilities.slsDeleteDomain(testName, RANDOM_STRING);
+  //     await utilities.sleep(60);
+  //     await utilities.slsCreateDomain(testName, RANDOM_STRING);
+  //     await utilities.sleep(60);
+  //     await utilities.slsDeploy(testName, RANDOM_STRING);
+  //   });
+
+  //   it("Creates a basepath mapping", async () => {
+  //     const basePath = await utilities.getBasePath(testURL);
+  //     expect(basePath).to.equal("api");
+  //   });
+
+  //   after(async () => {
+  //     await utilities.destroyResources(testName, testURL, RANDOM_STRING);
+  //   });
+  // });
+
+
+  // describe("Basepath Mapping Is Empty And Fix Works", function () { // eslint-disable-line func-names
+  //   this.timeout(15 * 60 * 1000); // 15 minutes in milliseconds
+  //   const testName = "null-basepath-mapping";
+  //   const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
+
+  //   before(async () => {
+  //     // Perform sequence of commands to replicate basepath mapping issue
+  //     // Sleep for a min b/w commands in order to avoid rate limiting.
+  //     await utilities.slsCreateDomain(testName, RANDOM_STRING);
+  //     await utilities.sleep(60);
+  //     await utilities.slsDeploy(testName, RANDOM_STRING);
+  //     await utilities.sleep(60);
+  //     await utilities.slsDeleteDomain(testName, RANDOM_STRING);
+  //     await utilities.sleep(60);
+  //     await utilities.slsRemove(testName, RANDOM_STRING);
+  //     await utilities.sleep(60);
+  //     await utilities.slsCreateDomain(testName, RANDOM_STRING);
+  //     await utilities.sleep(60);
+  //     await utilities.slsDeploy(testName, RANDOM_STRING);
+  //   });
+
+  //   it("Creates a basepath mapping", async () => {
+  //     const basePath = await utilities.getBasePath(testURL);
+  //     expect(basePath).to.equal("(none)");
+  //   });
+
+  //   after(async () => {
+  //     await utilities.destroyResources(testName, testURL, RANDOM_STRING);
+  //   });
+  // });
+
+  describe("Create domain is idempotent", function () { // eslint-disable-line func-names
+    this.timeout(15 * 60 * 1000); // 15 minutes in milliseconds
+    const testName = "create-domain-idempotent";
     const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
 
-    before(async () => {
-      const created = await utilities.createResources(testName, testURL, RANDOM_STRING, false);
-      if (!created) {
-        throw new utilities.CreationError("Resources failed to create.");
-      }
-    });
-
-    it("Does not create a domain", async () => {
-      const data = await utilities.curlUrl(`https://${testURL}/hello-world`);
-      expect(data).to.equal(null);
+    it("Creates a domain multiple times without failure", async () => {
+      let createDomain = true;
+      let deploySuccess;
+      createDomain = createDomain && await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      await utilities.sleep(60);
+      createDomain = createDomain && await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      await utilities.sleep(60);
+      createDomain = createDomain && await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      await utilities.sleep(60);
+      deploySuccess = await utilities.slsDeploy(testName, RANDOM_STRING);
+      expect(createDomain).to.equal(true);
+      expect(deploySuccess).to.equal(true);
     });
 
     after(async () => {
@@ -144,89 +254,23 @@ describe("Integration Tests", function () { // eslint-disable-line func-names
     });
   });
 
-  describe("Basepath Mapping Is Empty", function () { // eslint-disable-line func-names
+  describe("Deploy is idempotent", function () { // eslint-disable-line func-names
     this.timeout(15 * 60 * 1000); // 15 minutes in milliseconds
-    const testName = "null-basepath-mapping";
+    const testName = "deploy-idempotent";
     const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
 
-    before(async () => {
-      // Perform sequence of commands to replicate basepath mapping issue
-      // Sleep for a min b/w commands in order to avoid rate limiting.
-      await utilities.slsCreateDomain(testName, RANDOM_STRING);
+    it("Deploys multiple times without failure", async () => {
+      let createDomain;
+      let deploySuccess = true;
+      createDomain = await utilities.slsCreateDomain(testName, RANDOM_STRING);
       await utilities.sleep(60);
-      await utilities.slsDeploy(testName, RANDOM_STRING);
+      deploySuccess = deploySuccess && await utilities.slsDeploy(testName, RANDOM_STRING);
       await utilities.sleep(60);
-      await utilities.slsDeleteDomain(testName, RANDOM_STRING);
+      deploySuccess = deploySuccess && await utilities.slsDeploy(testName, RANDOM_STRING);
       await utilities.sleep(60);
-      await utilities.slsCreateDomain(testName, RANDOM_STRING);
-      await utilities.sleep(60);
-      await utilities.slsDeploy(testName, RANDOM_STRING);
-    });
-
-    it("Creates a basepath mapping", async () => {
-      const basePath = await utilities.getBasePath(testURL);
-      expect(basePath).to.equal("(none)");
-    });
-
-    after(async () => {
-      await utilities.destroyResources(testName, testURL, RANDOM_STRING);
-    });
-  });
-
-  describe("Basepath Mapping Is Set", function () { // eslint-disable-line func-names
-    this.timeout(15 * 60 * 1000); // 15 minutes in milliseconds
-    const testName = "basepath-mapping";
-    const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
-
-    before(async () => {
-      // Perform sequence of commands to replicate basepath mapping issue
-      // Sleep for a min b/w commands in order to avoid rate limiting.
-      await utilities.slsCreateDomain(testName, RANDOM_STRING);
-      await utilities.sleep(60);
-      await utilities.slsDeploy(testName, RANDOM_STRING);
-      await utilities.sleep(60);
-      await utilities.slsDeleteDomain(testName, RANDOM_STRING);
-      await utilities.sleep(60);
-      await utilities.slsCreateDomain(testName, RANDOM_STRING);
-      await utilities.sleep(60);
-      await utilities.slsDeploy(testName, RANDOM_STRING);
-    });
-
-    it("Creates a basepath mapping", async () => {
-      const basePath = await utilities.getBasePath(testURL);
-      expect(basePath).to.equal("api");
-    });
-
-    after(async () => {
-      await utilities.destroyResources(testName, testURL, RANDOM_STRING);
-    });
-  });
-
-
-  describe("Basepath Mapping Is Empty And Fix Works", function () { // eslint-disable-line func-names
-    this.timeout(15 * 60 * 1000); // 15 minutes in milliseconds
-    const testName = "null-basepath-mapping";
-    const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
-
-    before(async () => {
-      // Perform sequence of commands to replicate basepath mapping issue
-      // Sleep for a min b/w commands in order to avoid rate limiting.
-      await utilities.slsCreateDomain(testName, RANDOM_STRING);
-      await utilities.sleep(60);
-      await utilities.slsDeploy(testName, RANDOM_STRING);
-      await utilities.sleep(60);
-      await utilities.slsDeleteDomain(testName, RANDOM_STRING);
-      await utilities.sleep(60);
-      await utilities.slsRemove(testName, RANDOM_STRING);
-      await utilities.sleep(60);
-      await utilities.slsCreateDomain(testName, RANDOM_STRING);
-      await utilities.sleep(60);
-      await utilities.slsDeploy(testName, RANDOM_STRING);
-    });
-
-    it("Creates a basepath mapping", async () => {
-      const basePath = await utilities.getBasePath(testURL);
-      expect(basePath).to.equal("(none)");
+      deploySuccess = deploySuccess && await utilities.slsDeploy(testName, RANDOM_STRING);
+      expect(createDomain).to.equal(true);
+      expect(deploySuccess).to.equal(true);
     });
 
     after(async () => {

--- a/test/integration-tests/integration.test.js
+++ b/test/integration-tests/integration.test.js
@@ -86,149 +86,149 @@ const testCases = [
 describe("Integration Tests", function () { // eslint-disable-line func-names
   this.timeout(SIX_HOURS); // 6 hours to allow for dns to propogate
 
-  // describe("Domain Manager Is Enabled", function () { // eslint-disable-line func-names
-  //   this.timeout(SIX_HOURS);
+  describe("Domain Manager Is Enabled", function () { // eslint-disable-line func-names
+    this.timeout(SIX_HOURS);
 
-  //   itParam("${value.testDescription}", testCases, async (value) => { // eslint-disable-line no-template-curly-in-string
-  //     let restApiInfo;
-  //     if (value.createApiGateway) {
-  //       restApiInfo = await utilities.setupApiGatewayResources(RANDOM_STRING);
-  //     }
-  //     const created = await utilities.createResources(value.testFolder,
-  //         value.testDomain, RANDOM_STRING, true);
-  //     if (!created) {
-  //       throw new utilities.CreationError("Resources failed to create.");
-  //     } else {
-  //       const stage = await utilities.getStage(value.testDomain);
-  //       expect(stage).to.equal(value.testStage);
+    itParam("${value.testDescription}", testCases, async (value) => { // eslint-disable-line no-template-curly-in-string
+      let restApiInfo;
+      if (value.createApiGateway) {
+        restApiInfo = await utilities.setupApiGatewayResources(RANDOM_STRING);
+      }
+      const created = await utilities.createResources(value.testFolder,
+          value.testDomain, RANDOM_STRING, true);
+      if (!created) {
+        throw new utilities.CreationError("Resources failed to create.");
+      } else {
+        const stage = await utilities.getStage(value.testDomain);
+        expect(stage).to.equal(value.testStage);
 
-  //       const basePath = await utilities.getBasePath(value.testDomain);
-  //       expect(basePath).to.equal(value.testBasePath);
+        const basePath = await utilities.getBasePath(value.testDomain);
+        expect(basePath).to.equal(value.testBasePath);
 
-  //       const endpoint = await utilities.getEndpointType(value.testDomain);
-  //       expect(endpoint).to.equal(value.testEndpoint);
+        const endpoint = await utilities.getEndpointType(value.testDomain);
+        expect(endpoint).to.equal(value.testEndpoint);
 
-  //       const status = await utilities.curlUrl(value.testURL);
-  //       expect(status).to.equal(200);
-  //     }
-  //     await utilities.destroyResources(value.testFolder, value.testDomain, RANDOM_STRING);
-  //     if (value.createApiGateway) {
-  //       await utilities.deleteApiGatewayResources(restApiInfo.restApiId);
-  //     }
-  //   });
-  // });
+        const status = await utilities.curlUrl(value.testURL);
+        expect(status).to.equal(200);
+      }
+      await utilities.destroyResources(value.testFolder, value.testDomain, RANDOM_STRING);
+      if (value.createApiGateway) {
+        await utilities.deleteApiGatewayResources(restApiInfo.restApiId);
+      }
+    });
+  });
 
-  // describe("Domain Manager Is Not Enabled", function () { // eslint-disable-line func-names
-  //   this.timeout(5 * 60 * 1000); // 5 minutes in milliseconds
-  //   const testName = "disabled";
-  //   const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
+  describe("Domain Manager Is Not Enabled", function () { // eslint-disable-line func-names
+    this.timeout(5 * 60 * 1000); // 5 minutes in milliseconds
+    const testName = "disabled";
+    const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
 
-  //   before(async () => {
-  //     const created = await utilities.createResources(testName, testURL, RANDOM_STRING, false);
-  //     if (!created) {
-  //       throw new utilities.CreationError("Resources failed to create.");
-  //     }
-  //   });
+    before(async () => {
+      const created = await utilities.createResources(testName, testURL, RANDOM_STRING, false);
+      if (!created) {
+        throw new utilities.CreationError("Resources failed to create.");
+      }
+    });
 
-  //   it("Does not create a domain", async () => {
-  //     const data = await utilities.curlUrl(`https://${testURL}/hello-world`);
-  //     expect(data).to.equal(null);
-  //   });
+    it("Does not create a domain", async () => {
+      const data = await utilities.curlUrl(`https://${testURL}/hello-world`);
+      expect(data).to.equal(null);
+    });
 
-  //   after(async () => {
-  //     await utilities.destroyResources(testName, testURL, RANDOM_STRING);
-  //   });
-  // });
+    after(async () => {
+      await utilities.destroyResources(testName, testURL, RANDOM_STRING);
+    });
+  });
 
-  // describe("Basepath Mapping Is Empty", function () { // eslint-disable-line func-names
-  //   this.timeout(15 * 60 * 1000); // 15 minutes in milliseconds
-  //   const testName = "null-basepath-mapping";
-  //   const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
+  describe("Basepath Mapping Is Empty", function () { // eslint-disable-line func-names
+    this.timeout(15 * 60 * 1000); // 15 minutes in milliseconds
+    const testName = "null-basepath-mapping";
+    const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
 
-  //   before(async () => {
-  //     // Perform sequence of commands to replicate basepath mapping issue
-  //     // Sleep for a min b/w commands in order to avoid rate limiting.
-  //     await utilities.slsCreateDomain(testName, RANDOM_STRING);
-  //     await utilities.sleep(60);
-  //     await utilities.slsDeploy(testName, RANDOM_STRING);
-  //     await utilities.sleep(60);
-  //     await utilities.slsDeleteDomain(testName, RANDOM_STRING);
-  //     await utilities.sleep(60);
-  //     await utilities.slsCreateDomain(testName, RANDOM_STRING);
-  //     await utilities.sleep(60);
-  //     await utilities.slsDeploy(testName, RANDOM_STRING);
-  //   });
+    before(async () => {
+      // Perform sequence of commands to replicate basepath mapping issue
+      // Sleep for a min b/w commands in order to avoid rate limiting.
+      await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      await utilities.sleep(60);
+      await utilities.slsDeploy(testName, RANDOM_STRING);
+      await utilities.sleep(60);
+      await utilities.slsDeleteDomain(testName, RANDOM_STRING);
+      await utilities.sleep(60);
+      await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      await utilities.sleep(60);
+      await utilities.slsDeploy(testName, RANDOM_STRING);
+    });
 
-  //   it("Creates a basepath mapping", async () => {
-  //     const basePath = await utilities.getBasePath(testURL);
-  //     expect(basePath).to.equal("(none)");
-  //   });
+    it("Creates a basepath mapping", async () => {
+      const basePath = await utilities.getBasePath(testURL);
+      expect(basePath).to.equal("(none)");
+    });
 
-  //   after(async () => {
-  //     await utilities.destroyResources(testName, testURL, RANDOM_STRING);
-  //   });
-  // });
+    after(async () => {
+      await utilities.destroyResources(testName, testURL, RANDOM_STRING);
+    });
+  });
 
-  // describe("Basepath Mapping Is Set", function () { // eslint-disable-line func-names
-  //   this.timeout(15 * 60 * 1000); // 15 minutes in milliseconds
-  //   const testName = "basepath-mapping";
-  //   const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
+  describe("Basepath Mapping Is Set", function () { // eslint-disable-line func-names
+    this.timeout(15 * 60 * 1000); // 15 minutes in milliseconds
+    const testName = "basepath-mapping";
+    const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
 
-  //   before(async () => {
-  //     // Perform sequence of commands to replicate basepath mapping issue
-  //     // Sleep for a min b/w commands in order to avoid rate limiting.
-  //     await utilities.slsCreateDomain(testName, RANDOM_STRING);
-  //     await utilities.sleep(60);
-  //     await utilities.slsDeploy(testName, RANDOM_STRING);
-  //     await utilities.sleep(60);
-  //     await utilities.slsDeleteDomain(testName, RANDOM_STRING);
-  //     await utilities.sleep(60);
-  //     await utilities.slsCreateDomain(testName, RANDOM_STRING);
-  //     await utilities.sleep(60);
-  //     await utilities.slsDeploy(testName, RANDOM_STRING);
-  //   });
+    before(async () => {
+      // Perform sequence of commands to replicate basepath mapping issue
+      // Sleep for a min b/w commands in order to avoid rate limiting.
+      await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      await utilities.sleep(60);
+      await utilities.slsDeploy(testName, RANDOM_STRING);
+      await utilities.sleep(60);
+      await utilities.slsDeleteDomain(testName, RANDOM_STRING);
+      await utilities.sleep(60);
+      await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      await utilities.sleep(60);
+      await utilities.slsDeploy(testName, RANDOM_STRING);
+    });
 
-  //   it("Creates a basepath mapping", async () => {
-  //     const basePath = await utilities.getBasePath(testURL);
-  //     expect(basePath).to.equal("api");
-  //   });
+    it("Creates a basepath mapping", async () => {
+      const basePath = await utilities.getBasePath(testURL);
+      expect(basePath).to.equal("api");
+    });
 
-  //   after(async () => {
-  //     await utilities.destroyResources(testName, testURL, RANDOM_STRING);
-  //   });
-  // });
+    after(async () => {
+      await utilities.destroyResources(testName, testURL, RANDOM_STRING);
+    });
+  });
 
 
-  // describe("Basepath Mapping Is Empty And Fix Works", function () { // eslint-disable-line func-names
-  //   this.timeout(15 * 60 * 1000); // 15 minutes in milliseconds
-  //   const testName = "null-basepath-mapping";
-  //   const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
+  describe("Basepath Mapping Is Empty And Fix Works", function () { // eslint-disable-line func-names
+    this.timeout(15 * 60 * 1000); // 15 minutes in milliseconds
+    const testName = "null-basepath-mapping";
+    const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
 
-  //   before(async () => {
-  //     // Perform sequence of commands to replicate basepath mapping issue
-  //     // Sleep for a min b/w commands in order to avoid rate limiting.
-  //     await utilities.slsCreateDomain(testName, RANDOM_STRING);
-  //     await utilities.sleep(60);
-  //     await utilities.slsDeploy(testName, RANDOM_STRING);
-  //     await utilities.sleep(60);
-  //     await utilities.slsDeleteDomain(testName, RANDOM_STRING);
-  //     await utilities.sleep(60);
-  //     await utilities.slsRemove(testName, RANDOM_STRING);
-  //     await utilities.sleep(60);
-  //     await utilities.slsCreateDomain(testName, RANDOM_STRING);
-  //     await utilities.sleep(60);
-  //     await utilities.slsDeploy(testName, RANDOM_STRING);
-  //   });
+    before(async () => {
+      // Perform sequence of commands to replicate basepath mapping issue
+      // Sleep for a min b/w commands in order to avoid rate limiting.
+      await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      await utilities.sleep(60);
+      await utilities.slsDeploy(testName, RANDOM_STRING);
+      await utilities.sleep(60);
+      await utilities.slsDeleteDomain(testName, RANDOM_STRING);
+      await utilities.sleep(60);
+      await utilities.slsRemove(testName, RANDOM_STRING);
+      await utilities.sleep(60);
+      await utilities.slsCreateDomain(testName, RANDOM_STRING);
+      await utilities.sleep(60);
+      await utilities.slsDeploy(testName, RANDOM_STRING);
+    });
 
-  //   it("Creates a basepath mapping", async () => {
-  //     const basePath = await utilities.getBasePath(testURL);
-  //     expect(basePath).to.equal("(none)");
-  //   });
+    it("Creates a basepath mapping", async () => {
+      const basePath = await utilities.getBasePath(testURL);
+      expect(basePath).to.equal("(none)");
+    });
 
-  //   after(async () => {
-  //     await utilities.destroyResources(testName, testURL, RANDOM_STRING);
-  //   });
-  // });
+    after(async () => {
+      await utilities.destroyResources(testName, testURL, RANDOM_STRING);
+    });
+  });
 
   describe("Create domain is idempotent", function () { // eslint-disable-line func-names
     this.timeout(15 * 60 * 1000); // 15 minutes in milliseconds

--- a/test/integration-tests/test-utilities.js
+++ b/test/integration-tests/test-utilities.js
@@ -26,12 +26,28 @@ function sleep(seconds) {
 }
 
 /**
+ * Executes given shell command.
+ * @param cmd shell command to execute
+ * @returns {Promise<boolean>} Resolves true if successfully executed, else false
+ */
+async function exec(cmd) {
+  return new Promise((resolve) => {
+    shell.exec(`${cmd}`, { silent: false }, (err, stdout, stderr) => {
+      if (err || stderr) {
+        return resolve(false);
+      }
+      return resolve(true);
+    });
+  });
+}
+
+/**
  * Links current serverless-domain-manager to global node_modules in order to run tests.
  * @returns {Promise<boolean>} Resolves true if successfully linked, else false.
  */
 async function linkPackages() {
   return new Promise((resolve) => {
-    shell.exec("npm link serverless-domain-manager", { silent: true }, (err, stdout, stderr) => {
+    shell.exec("npm link serverless-domain-manager", { silent: false }, (err, stdout, stderr) => {
       if (err || stderr) {
         return resolve(false);
       }
@@ -119,7 +135,7 @@ async function getBasePath(url) {
  */
 function slsCreateDomain(folderName, domainIdentifier) {
   return new Promise((resolve) => {
-    shell.exec(`cd 'test/integration-tests/${folderName}' && sls create_domain --RANDOM_STRING ${domainIdentifier}`, { silent: true }, (err, stdout, stderr) => {
+    shell.exec(`cd 'test/integration-tests/${folderName}' && sls create_domain --RANDOM_STRING ${domainIdentifier}`, { silent: false }, (err, stdout, stderr) => {
       if (err || stderr) {
         return resolve(false);
       }
@@ -136,7 +152,7 @@ function slsCreateDomain(folderName, domainIdentifier) {
  */
 function slsDeploy(folderName, domainIdentifier) {
   return new Promise((resolve) => {
-    shell.exec(`cd 'test/integration-tests/${folderName}' && sls deploy --RANDOM_STRING ${domainIdentifier}`, { silent: true }, (err, stdout, stderr) => {
+    shell.exec(`cd 'test/integration-tests/${folderName}' && sls deploy --RANDOM_STRING ${domainIdentifier}`, { silent: false }, (err, stdout, stderr) => {
       if (err || stderr) {
         return resolve(false);
       }
@@ -205,7 +221,7 @@ async function verifyDnsPropogation(url, enabled) {
  */
 function slsDeleteDomain(folderName, domainIdentifier) {
   return new Promise((resolve) => {
-    shell.exec(`cd 'test/integration-tests/${folderName}' && sls delete_domain --RANDOM_STRING ${domainIdentifier}`, { silent: true }, (err, stdout, stderr) => {
+    shell.exec(`cd 'test/integration-tests/${folderName}' && sls delete_domain --RANDOM_STRING ${domainIdentifier}`, { silent: false }, (err, stdout, stderr) => {
       if (err || stderr) {
         return resolve(false);
       }
@@ -222,7 +238,7 @@ function slsDeleteDomain(folderName, domainIdentifier) {
  */
 function slsRemove(folderName, domainIdentifier) {
   return new Promise((resolve) => {
-    shell.exec(`cd 'test/integration-tests/${folderName}' && sls remove --RANDOM_STRING ${domainIdentifier}`, { silent: true }, (err, stdout, stderr) => {
+    shell.exec(`cd 'test/integration-tests/${folderName}' && sls remove --RANDOM_STRING ${domainIdentifier}`, { silent: false }, (err, stdout, stderr) => {
       if (err || stderr) {
         return resolve(false);
       }
@@ -312,6 +328,7 @@ module.exports = {
   curlUrl,
   createResources,
   destroyResources,
+  exec,
   verifyDnsPropogation,
   dnsLookup,
   slsCreateDomain,

--- a/test/integration-tests/test-utilities.js
+++ b/test/integration-tests/test-utilities.js
@@ -32,7 +32,7 @@ function sleep(seconds) {
  */
 async function exec(cmd) {
   return new Promise((resolve) => {
-    shell.exec(`${cmd}`, { silent: false }, (err, stdout, stderr) => {
+    shell.exec(`${cmd}`, { silent: true }, (err, stdout, stderr) => {
       if (err || stderr) {
         return resolve(false);
       }
@@ -42,12 +42,24 @@ async function exec(cmd) {
 }
 
 /**
+ * Move item in folderName to created tempDir
+ * @param {string} tempDir
+ * @param {string} folderName
+ */
+async function createTempDir(tempDir, folderName) {
+  await exec(`rm -rf ${tempDir}`);
+  await exec(`mkdir -p ${tempDir} && cp -R test/integration-tests/${folderName}/. ${tempDir}`);
+  await exec(`mkdir -p ${tempDir}/node_modules/serverless-domain-manager`);
+  await exec(`cp -R . ${tempDir}/node_modules/serverless-domain-manager`);
+}
+
+/**
  * Links current serverless-domain-manager to global node_modules in order to run tests.
  * @returns {Promise<boolean>} Resolves true if successfully linked, else false.
  */
 async function linkPackages() {
   return new Promise((resolve) => {
-    shell.exec("npm link serverless-domain-manager", { silent: false }, (err, stdout, stderr) => {
+    shell.exec("npm link serverless-domain-manager", { silent: true }, (err, stdout, stderr) => {
       if (err || stderr) {
         return resolve(false);
       }
@@ -128,52 +140,6 @@ async function getBasePath(url) {
 }
 
 /**
- * Runs `sls create_domain` for the given folder
- * @param folderName
- * @param domainIdentifier Random alphanumeric string to identify specific run of integration tests.
- * @returns {Promise<any>}
- */
-function slsCreateDomain(folderName, domainIdentifier) {
-  return new Promise((resolve) => {
-    shell.exec(`cd 'test/integration-tests/${folderName}' && sls create_domain --RANDOM_STRING ${domainIdentifier}`, { silent: false }, (err, stdout, stderr) => {
-      if (err || stderr) {
-        return resolve(false);
-      }
-      return resolve(true);
-    });
-  });
-}
-
-/**
- * Runs `sls deploy` for the given folder
- * @param folderName
- * @param domainIdentifier Random alphanumeric string to identify specific run of integration tests.
- * @returns {Promise<any>}
- */
-function slsDeploy(folderName, domainIdentifier) {
-  return new Promise((resolve) => {
-    shell.exec(`cd 'test/integration-tests/${folderName}' && sls deploy --RANDOM_STRING ${domainIdentifier}`, { silent: false }, (err, stdout, stderr) => {
-      if (err || stderr) {
-        return resolve(false);
-      }
-      return resolve(true);
-    });
-  });
-}
-
-/**
- * Runs both `sls create_domain` and `sls deploy`
- * @param folderName
- * @param domainIdentifier Random alphanumeric string to identify specific run of integration tests.
- * @returns {Promise<*>}
- */
-async function deployLambdas(folderName, domainIdentifier) {
-  const created = await slsCreateDomain(folderName, domainIdentifier);
-  const deployed = await slsDeploy(folderName, domainIdentifier);
-  return created && deployed;
-}
-
-/**
  * Looks up DNS records for the given url
  * @param url
  * @returns {Promise<boolean>} Resolves true if DNS records exist, else false.
@@ -214,93 +180,6 @@ async function verifyDnsPropogation(url, enabled) {
 }
 
 /**
- * Runs `sls delete_domain` for the given folder
- * @param folderName
- * @param domainIdentifier Random alphanumeric string to identify specific run of integration tests.
- * @returns {Promise<any>}
- */
-function slsDeleteDomain(folderName, domainIdentifier) {
-  return new Promise((resolve) => {
-    shell.exec(`cd 'test/integration-tests/${folderName}' && sls delete_domain --RANDOM_STRING ${domainIdentifier}`, { silent: false }, (err, stdout, stderr) => {
-      if (err || stderr) {
-        return resolve(false);
-      }
-      return resolve(true);
-    });
-  });
-}
-
-/**
- * Runs `sls remove` for the given folder
- * @param folderName
- * @param domainIdentifier Random alphanumeric string to identify specific run of integration tests.
- * @returns {Promise<any>}
- */
-function slsRemove(folderName, domainIdentifier) {
-  return new Promise((resolve) => {
-    shell.exec(`cd 'test/integration-tests/${folderName}' && sls remove --RANDOM_STRING ${domainIdentifier}`, { silent: false }, (err, stdout, stderr) => {
-      if (err || stderr) {
-        return resolve(false);
-      }
-      return resolve(true);
-    });
-  });
-}
-
-/**
- * Runs both `sls delete_domain` and `sls remove`
- * @param folderName
- * @param domainIdentifier Random alphanumeric string to identify specific run of integration tests.
- * @returns {Promise<*>}
- */
-async function removeLambdas(folderName, domainIdentifier) {
-  const removed = await slsRemove(folderName, domainIdentifier);
-  const deleted = await slsDeleteDomain(folderName, domainIdentifier);
-  return deleted && removed;
-}
-
-/**
- * Wraps creation of testing resources.
- * @param folderName
- * @param url
- * @param domainIdentifier Random alphanumeric string to identify specific run of integration tests.
- * @param enabled
- * @returns {Promise<boolean>} Resolves true if resources created, else false.
- */
-async function createResources(folderName, url, domainIdentifier, enabled) {
-  console.debug(`\tCreating Resources for ${url}`); // eslint-disable-line no-console
-  const created = await deployLambdas(folderName, domainIdentifier);
-  let dnsVerified = false;
-  if (created) {
-    dnsVerified = await verifyDnsPropogation(url, enabled);
-  }
-  if (created && dnsVerified) {
-    console.debug("\tResources Created"); // eslint-disable-line no-console
-  } else {
-    console.debug("\tResources Failed to Create"); // eslint-disable-line no-console
-  }
-  return created && dnsVerified;
-}
-
-/**
- * Wraps deletion of testing resources.
- * @param folderName
- * @param url
- * @param domainIdentifier Random alphanumeric string to identify specific run of integration tests.
- * @returns {Promise<boolean>} Resolves true if resources destroyed, else false.
- */
-async function destroyResources(folderName, url, domainIdentifier) {
-  console.debug(`\tCleaning Up Resources for ${url}`); // eslint-disable-line no-console
-  const removed = await removeLambdas(folderName, domainIdentifier);
-  if (removed) {
-    console.debug("\tResources Cleaned Up"); // eslint-disable-line no-console
-  } else {
-    console.debug("\tFailed to Clean Up Resources"); // eslint-disable-line no-console
-  }
-  return removed;
-}
-
-/**
  * Make API Gateway calls to create an API Gateway
  * @param {string} randString
  * @return {Object} Contains restApiId and resourceId
@@ -324,9 +203,146 @@ async function deleteApiGatewayResources(restApiId) {
   return apiGateway.deleteRestApi({ restApiId }).promise();
 }
 
+/**
+ * Runs `sls create_domain` for the given folder
+ * @param tempDir
+ * @param domainIdentifier Random alphanumeric string to identify specific run of integration tests.
+ * @returns {Promise<any>}
+ */
+function slsCreateDomain(tempDir, domainIdentifier) {
+  return new Promise((resolve) => {
+    shell.exec(`cd ${tempDir} && sls create_domain --RANDOM_STRING ${domainIdentifier}`, { silent: true }, (err, stdout, stderr) => {
+      if (err || stderr) {
+        return resolve(false);
+      }
+      return resolve(true);
+    });
+  });
+}
+
+/**
+ * Runs `sls deploy` for the given folder
+ * @param tempDir
+ * @param domainIdentifier Random alphanumeric string to identify specific run of integration tests.
+ * @returns {Promise<any>}
+ */
+function slsDeploy(tempDir, domainIdentifier) {
+  return new Promise((resolve) => {
+    shell.exec(`cd ${tempDir} && sls deploy --RANDOM_STRING ${domainIdentifier}`, { silent: true }, (err, stdout, stderr) => {
+      if (err || stderr) {
+        return resolve(false);
+      }
+      return resolve(true);
+    });
+  });
+}
+
+/**
+ * Runs `sls delete_domain` for the given folder
+ * @param tempDir
+ * @param domainIdentifier Random alphanumeric string to identify specific run of integration tests.
+ * @returns {Promise<any>}
+ */
+function slsDeleteDomain(tempDir, domainIdentifier) {
+  return new Promise((resolve) => {
+    shell.exec(`cd ${tempDir} && sls delete_domain --RANDOM_STRING ${domainIdentifier}`, { silent: true }, (err, stdout, stderr) => {
+      if (err || stderr) {
+        return resolve(false);
+      }
+      return resolve(true);
+    });
+  });
+}
+
+/**
+ * Runs `sls remove` for the given folder
+ * @param tempDir
+ * @param domainIdentifier Random alphanumeric string to identify specific run of integration tests.
+ * @returns {Promise<any>}
+ */
+function slsRemove(tempDir, domainIdentifier) {
+  return new Promise((resolve) => {
+    shell.exec(`cd ${tempDir} && sls remove --RANDOM_STRING ${domainIdentifier}`, { silent: true }, (err, stdout, stderr) => {
+      if (err || stderr) {
+        return resolve(false);
+      }
+      return resolve(true);
+    });
+  });
+}
+
+/**
+ * Runs both `sls create_domain` and `sls deploy`
+ * @param tempDir
+ * @param domainIdentifier Random alphanumeric string to identify specific run of integration tests.
+ * @returns {Promise<*>}
+ */
+async function deployLambdas(tempDir, domainIdentifier) {
+  const created = await slsCreateDomain(tempDir, domainIdentifier);
+  const deployed = await slsDeploy(tempDir, domainIdentifier);
+  return created && deployed;
+}
+
+/**
+ * Runs both `sls delete_domain` and `sls remove`
+ * @param tempDir temp directory where code is being run from
+ * @param domainIdentifier Random alphanumeric string to identify specific run of integration tests.
+ * @returns {Promise<*>}
+ */
+async function removeLambdas(tempDir, domainIdentifier) {
+  const removed = await slsRemove(tempDir, domainIdentifier);
+  const deleted = await slsDeleteDomain(tempDir, domainIdentifier);
+  return deleted && removed;
+}
+
+/**
+ * Wraps creation of testing resources.
+ * @param folderName
+ * @param url
+ * @param domainIdentifier Random alphanumeric string to identify specific run of integration tests.
+ * @param enabled
+ * @returns {Promise<boolean>} Resolves true if resources created, else false.
+ */
+async function createResources(folderName, url, domainIdentifier, enabled) {
+  console.debug(`\tCreating Resources for ${url}`); // eslint-disable-line no-console
+  const tempDir = `~/tmp/domain-manager-test-${domainIdentifier}`;
+  await createTempDir(tempDir, folderName);
+  const created = await deployLambdas(tempDir, domainIdentifier);
+  let dnsVerified = false;
+  if (created) {
+    dnsVerified = await verifyDnsPropogation(url, enabled);
+  }
+  if (created && dnsVerified) {
+    console.debug("\tResources Created"); // eslint-disable-line no-console
+  } else {
+    console.debug("\tResources Failed to Create"); // eslint-disable-line no-console
+  }
+  return created && dnsVerified;
+}
+
+/**
+ * Wraps deletion of testing resources.
+ * @param url
+ * @param domainIdentifier Random alphanumeric string to identify specific run of integration tests.
+ * @returns {Promise<boolean>} Resolves true if resources destroyed, else false.
+ */
+async function destroyResources(url, domainIdentifier) {
+  console.debug(`\tCleaning Up Resources for ${url}`); // eslint-disable-line no-console
+  const tempDir = `~/tmp/domain-manager-test-${domainIdentifier}`;
+  const removed = await removeLambdas(tempDir, domainIdentifier);
+  await exec(`rm -rf ${tempDir}`);
+  if (removed) {
+    console.debug("\tResources Cleaned Up"); // eslint-disable-line no-console
+  } else {
+    console.debug("\tFailed to Clean Up Resources"); // eslint-disable-line no-console
+  }
+  return removed;
+}
+
 module.exports = {
   curlUrl,
   createResources,
+  createTempDir,
   destroyResources,
   exec,
   verifyDnsPropogation,

--- a/test/integration-tests/two-three-migration-basepath/handler.js
+++ b/test/integration-tests/two-three-migration-basepath/handler.js
@@ -1,0 +1,16 @@
+"use strict";
+
+module.exports.helloWorld = (event, context, callback) => {
+  const response = {
+    statusCode: 200,
+    headers: {
+      "Access-Control-Allow-Origin": "*", // Required for CORS support to work
+    },
+    body: JSON.stringify({
+      message: "Go Serverless v1.0! Your function executed successfully!",
+      input: event,
+    }),
+  };
+
+  callback(null, response);
+};

--- a/test/integration-tests/two-three-migration-basepath/serverless.yml
+++ b/test/integration-tests/two-three-migration-basepath/serverless.yml
@@ -1,0 +1,20 @@
+# Migrating from version 2 to version 3
+service: two-three-migration-basepath
+provider:
+  name: aws
+  runtime: nodejs6.10
+  region: us-west-2
+functions:
+  helloWorld:
+    handler: handler.helloWorld
+    events:
+      - http:
+          path: hello-world
+          method: get
+          cors: true
+plugins:
+  - serverless-domain-manager
+custom:
+  customDomain:
+    domainName: two-three-migration-default-${opt:RANDOM_STRING}.${env:TEST_DOMAIN}
+    basePath: api

--- a/test/integration-tests/two-three-migration-basepath/serverless.yml
+++ b/test/integration-tests/two-three-migration-basepath/serverless.yml
@@ -16,5 +16,5 @@ plugins:
   - serverless-domain-manager
 custom:
   customDomain:
-    domainName: two-three-migration-default-${opt:RANDOM_STRING}.${env:TEST_DOMAIN}
+    domainName: two-three-migration-basepath-${opt:RANDOM_STRING}.${env:TEST_DOMAIN}
     basePath: api

--- a/test/integration-tests/two-three-migration-default/handler.js
+++ b/test/integration-tests/two-three-migration-default/handler.js
@@ -1,0 +1,16 @@
+"use strict";
+
+module.exports.helloWorld = (event, context, callback) => {
+  const response = {
+    statusCode: 200,
+    headers: {
+      "Access-Control-Allow-Origin": "*", // Required for CORS support to work
+    },
+    body: JSON.stringify({
+      message: "Go Serverless v1.0! Your function executed successfully!",
+      input: event,
+    }),
+  };
+
+  callback(null, response);
+};

--- a/test/integration-tests/two-three-migration-default/serverless.yml
+++ b/test/integration-tests/two-three-migration-default/serverless.yml
@@ -1,0 +1,19 @@
+# Migrating from version 2 to version 3
+service: two-three-migration-default
+provider:
+  name: aws
+  runtime: nodejs6.10
+  region: us-west-2
+functions:
+  helloWorld:
+    handler: handler.helloWorld
+    events:
+      - http:
+          path: hello-world
+          method: get
+          cors: true
+plugins:
+  - serverless-domain-manager
+custom:
+  customDomain:
+    domainName: two-three-migration-default-${opt:RANDOM_STRING}.${env:TEST_DOMAIN}

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -621,7 +621,7 @@ describe("Custom Domain Plugin", () => {
     it("createDomain", async () => {
       AWS.mock("ACM", "listCertificates", certTestData);
       AWS.mock("APIGateway", "getDomainName", (params, callback) => {
-        callback(new Error("domain doesn\"t exist"), {});
+        callback({ code: "NotFoundException" }, {});
       });
       AWS.mock("APIGateway", "createDomainName", (params, callback) => {
         callback(null, { distributionDomainName: "foo", regionalHostedZoneId: "test_id" });
@@ -639,7 +639,7 @@ describe("Custom Domain Plugin", () => {
       plugin.acm = new aws.ACM();
       plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
       await plugin.createDomain();
-      expect(consoleOutput[0]).to.equal(`Custom domain ${plugin.givenDomainName} was created/updated.
+      expect(consoleOutput[0]).to.equal(`Custom domain ${plugin.givenDomainName} was created.
             New domains may take up to 40 minutes to be initialized.`);
     });
 

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -352,14 +352,13 @@ describe("Custom Domain Plugin", () => {
 
   describe("Gets Rest API correctly", () => {
     it("Fetches restApiId correctly when no ApiGateway specified", async () => {
-      AWS.mock("CloudFormation", "describeStackResources", (params, callback) => {
+      AWS.mock("CloudFormation", "describeStackResource", (params, callback) => {
         callback(null, {
-          StackResources:
-            [
-              { LogicalResourceId: "ApiGatewayRestApi", PhysicalResourceId: "test_rest_api_id" },
-              { LogicalResourceId: "LambdaPermission", PhysicalResourceId: "test_permission" },
-              { LogicalResourceId: "ApiGatewayResourceHello", PhysicalResourceId: "test_api_resource" },
-            ],
+          StackResourceDetail:
+            {
+              LogicalResourceId: "ApiGatewayRestApi",
+              PhysicalResourceId: "test_rest_api_id",
+            },
         });
       });
       const plugin = constructPlugin({
@@ -373,14 +372,13 @@ describe("Custom Domain Plugin", () => {
     });
 
     it("serverless.yml defines explicitly the apiGateway", async () => {
-      AWS.mock("CloudFormation", "describeStackResources", (params, callback) => {
+      AWS.mock("CloudFormation", "describeStackResource", (params, callback) => {
         callback(null, {
-          StackResources:
-            [
-              { LogicalResourceId: "ApiGatewayRestApi", PhysicalResourceId: "test_rest_api_id" },
-              { LogicalResourceId: "LambdaPermission", PhysicalResourceId: "test_permission" },
-              { LogicalResourceId: "ApiGatewayResourceHello", PhysicalResourceId: "test_api_resource" },
-            ],
+          StackResourceDetail:
+          {
+            LogicalResourceId: "ApiGatewayRestApi",
+            PhysicalResourceId: "test_rest_api_id",
+          },
         });
       });
 
@@ -495,15 +493,19 @@ describe("Custom Domain Plugin", () => {
       AWS.mock("APIGateway", "getDomainName", (params, callback) => {
         callback(null, { domainName: "fake_domain", distributionDomainName: "fake_dist_name" });
       });
+      AWS.mock("APIGateway", "getBasePathMappings", (params, callback) => {
+        callback(null, { items: [] });
+      });
       AWS.mock("APIGateway", "createBasePathMapping", (params, callback) => {
         callback(null, params);
       });
-      AWS.mock("CloudFormation", "describeStackResources", (params, callback) => {
+      AWS.mock("CloudFormation", "describeStackResource", (params, callback) => {
         callback(null, {
-          StackResources:
-            [
-              { LogicalResourceId: "ApiGatewayRestApi", PhysicalResourceId: "test_rest_api_id" },
-            ],
+          StackResourceDetail:
+          {
+            LogicalResourceId: "ApiGatewayRestApi",
+            PhysicalResourceId: "test_rest_api_id",
+          },
         });
       });
       const plugin = constructPlugin({ domainName: "test_domain"});

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -138,6 +138,34 @@ describe("Custom Domain Plugin", () => {
       });
     });
 
+    it("Updates basepath mapping", async () => {
+      AWS.mock("APIGateway", "updateBasePathMapping", (params, callback) => {
+        callback(null, params);
+      });
+      const plugin = constructPlugin({
+        basePath: "test_basepath",
+        domainName: "test_domain",
+      });
+      plugin.initializeVariables();
+      plugin.apigateway = new aws.APIGateway();
+      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
+      plugin.basePath = plugin.serverless.service.custom.customDomain.basePath;
+      const spy = chai.spy.on(plugin.apigateway, "updateBasePathMapping");
+
+      await plugin.updateBasePathMapping("old_basepath");
+      expect(spy).to.have.been.called.with({
+        basePath: "old_basepath",
+        domainName: "test_domain",
+        patchOperations: [
+          {
+            op: "replace",
+            path: "/basePath",
+            value: "test_basepath",
+          },
+        ],
+      });
+    });
+
     it("Add Domain Name and HostedZoneId to stack output", () => {
       const plugin = constructPlugin({
         domainName: "test_domain",

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -119,25 +119,17 @@ describe("Custom Domain Plugin", () => {
       AWS.mock("APIGateway", "createBasePathMapping", (params, callback) => {
         callback(null, params);
       });
-      AWS.mock("CloudFormation", "describeStackResources", (params, callback) => {
-        callback(null, {StackResources:
-          [
-            { LogicalResourceId: "ApiGatewayRestApi", PhysicalResourceId: "test_rest_api_id" },
-          ],
-        });
-      });
       const plugin = constructPlugin({
         basePath: "test_basepath",
         domainName: "test_domain",
       });
       plugin.initializeVariables();
-      plugin.cloudformation = new aws.CloudFormation();
       plugin.apigateway = new aws.APIGateway();
       plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
       plugin.basePath = plugin.serverless.service.custom.customDomain.basePath;
       const spy = chai.spy.on(plugin.apigateway, "createBasePathMapping");
 
-      await plugin.createBasePathMapping();
+      await plugin.createBasePathMapping("test_rest_api_id");
       expect(spy).to.have.been.called.with({
         basePath: "test_basepath",
         domainName: "test_domain",
@@ -163,26 +155,17 @@ describe("Custom Domain Plugin", () => {
       AWS.mock("APIGateway", "createBasePathMapping", (params, callback) => {
         callback(null, params);
       });
-      AWS.mock("CloudFormation", "describeStackResources", (params, callback) => {
-        callback(null, {
-          StackResources:
-            [
-              { LogicalResourceId: "ApiGatewayRestApi", PhysicalResourceId: "test_rest_api_id" },
-            ],
-        });
-      });
 
       const plugin = constructPlugin({
         basePath: "",
         domainName: "test_domain",
       });
       plugin.initializeVariables();
-      plugin.cloudformation = new aws.CloudFormation();
       plugin.apigateway = new aws.APIGateway();
       plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
       const spy = chai.spy.on(plugin.apigateway, "createBasePathMapping");
 
-      await plugin.createBasePathMapping();
+      await plugin.createBasePathMapping("test_rest_api_id");
       expect(spy).to.have.been.called.with({
         basePath: "(none)",
         domainName: "test_domain",
@@ -195,26 +178,17 @@ describe("Custom Domain Plugin", () => {
       AWS.mock("APIGateway", "createBasePathMapping", (params, callback) => {
         callback(null, params);
       });
-      AWS.mock("CloudFormation", "describeStackResources", (params, callback) => {
-        callback(null, {
-          StackResources:
-            [
-              { LogicalResourceId: "ApiGatewayRestApi", PhysicalResourceId: "test_rest_api_id" },
-            ],
-        });
-      });
 
       const plugin = constructPlugin({
         basePath: null,
         domainName: "test_domain",
       });
       plugin.initializeVariables();
-      plugin.cloudformation = new aws.CloudFormation();
       plugin.apigateway = new aws.APIGateway();
       plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
       const spy = chai.spy.on(plugin.apigateway, "createBasePathMapping");
 
-      await plugin.createBasePathMapping();
+      await plugin.createBasePathMapping("test_rest_api_id");
       expect(spy).to.have.been.called.with({
         basePath: "(none)",
         domainName: "test_domain",
@@ -227,25 +201,16 @@ describe("Custom Domain Plugin", () => {
       AWS.mock("APIGateway", "createBasePathMapping", (params, callback) => {
         callback(null, params);
       });
-      AWS.mock("CloudFormation", "describeStackResources", (params, callback) => {
-        callback(null, {
-          StackResources:
-            [
-              { LogicalResourceId: "ApiGatewayRestApi", PhysicalResourceId: "test_rest_api_id" },
-            ],
-        });
-      });
 
       const plugin = constructPlugin({
         domainName: "test_domain",
       });
       plugin.initializeVariables();
-      plugin.cloudformation = new aws.CloudFormation();
       plugin.apigateway = new aws.APIGateway();
       plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
       const spy = chai.spy.on(plugin.apigateway, "createBasePathMapping");
 
-      await plugin.createBasePathMapping();
+      await plugin.createBasePathMapping("test_rest_api_id");
       expect(spy).to.have.been.called.with({
         basePath: "(none)",
         domainName: "test_domain",
@@ -258,14 +223,6 @@ describe("Custom Domain Plugin", () => {
       AWS.mock("APIGateway", "createBasePathMapping", (params, callback) => {
         callback(null, params);
       });
-      AWS.mock("CloudFormation", "describeStackResources", (params, callback) => {
-        callback(null, {
-          StackResources:
-            [
-              { LogicalResourceId: "ApiGatewayRestApi", PhysicalResourceId: "test_rest_api_id" },
-            ],
-        });
-      });
 
       const plugin = constructPlugin({
         domainName: "test_domain",
@@ -276,7 +233,7 @@ describe("Custom Domain Plugin", () => {
       plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
       const spy = chai.spy.on(plugin.apigateway, "createBasePathMapping");
 
-      await plugin.createBasePathMapping();
+      await plugin.createBasePathMapping("test_rest_api_id");
       expect(spy).to.have.been.called.with({
         basePath: "(none)",
         domainName: "test_domain",


### PR DESCRIPTION
* when running `deploy`, update basepath if it already exists (fix for #194, possible fix for #192) 
* fix issue where `deploy` fails on projects with >100 resources (fixes #195)
To do:
* make `create_domain` idempotent (does not error out on multiple tries, fix for #193 ) 
