### PR TITLE
Custom Route53 Profile options

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -147,8 +147,23 @@ class ServerlessCustomDomain {
         if (this.enabled) {
             const credentials = this.serverless.providers.aws.getCredentials();
 
+            const domainProfile = this.serverless.service.custom.customDomain.route53Profile;
+            if (domainProfile) {
+                const r53Credentials =
+                    new this.serverless.providers.aws.sdk.SharedIniFileCredentials({ profile: domainProfile });
+                const r53Region =
+                    this.serverless.service.custom.customDomain.route53Region
+                    || this.serverless.providers.aws.getRegion()
+                    || "us-east-1";
+                this.route53 = new this.serverless.providers.aws.sdk.Route53({
+                    credentials: r53Credentials,
+                    region: r53Region,
+                });
+            } else {
+                this.route53 = new this.serverless.providers.aws.sdk.Route53(credentials);
+            }
+
             this.apigateway = new this.serverless.providers.aws.sdk.APIGateway(credentials);
-            this.route53 = new this.serverless.providers.aws.sdk.Route53(credentials);
             this.cloudformation = new this.serverless.providers.aws.sdk.CloudFormation(credentials);
 
             this.givenDomainName = this.serverless.service.custom.customDomain.domainName;

--- a/index.ts
+++ b/index.ts
@@ -408,7 +408,7 @@ class ServerlessCustomDomain {
         try {
             do {
                 hostedZoneData = await this.route53.listHostedZones({
-                    Marker: hostedZoneData && hostedZoneData.IsTruncated ? hostedZoneData.Marker : undefined,
+                    Marker: hostedZoneData && hostedZoneData.IsTruncated ? hostedZoneData.NextMarker : undefined,
                 }).promise();
                 targetHostedZone = hostedZoneData.HostedZones
                     .filter((hostedZone) => {

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -33,6 +33,11 @@ const testCreds = {
   sessionToken: "test_session",
 };
 
+const testRoute53Domain = {
+  route53Profile: "test-profile",
+  route53Region: "us-moon-42",
+};
+
 const constructPlugin = (customDomainOptions) => {
   aws.config.update(testCreds);
   aws.config.region = "eu-west-1";
@@ -51,6 +56,7 @@ const constructPlugin = (customDomainOptions) => {
           APIGateway: aws.APIGateway,
           CloudFormation: aws.CloudFormation,
           Route53: aws.Route53,
+          SharedIniFileCredentials: aws.SharedIniFileCredentials,
         },
       },
     },
@@ -66,6 +72,8 @@ const constructPlugin = (customDomainOptions) => {
           endpointType: customDomainOptions.endpointType,
           hostedZoneId: customDomainOptions.hostedZoneId,
           hostedZonePrivate: customDomainOptions.hostedZonePrivate,
+          route53Profile: customDomainOptions.route53Profile,
+          route53Region: customDomainOptions.route53Region,
           stage: customDomainOptions.stage,
         },
       },
@@ -87,6 +95,27 @@ const constructPlugin = (customDomainOptions) => {
   };
   return new ServerlessCustomDomain(serverless, options);
 };
+
+describe("Custom R53 Profile", () => {
+  it("uses default credentials for route 53", () => {
+    const plugin = constructPlugin({});
+    plugin.initializeVariables();
+
+    const returnedCreds = plugin.route53.config.credentials;
+
+    expect(returnedCreds.accessKeyId).to.equal(testCreds.accessKeyId);
+    expect(returnedCreds.sessionToken).to.equal(testCreds.sessionToken);
+  });
+
+  it("overrides credentials for route 53", () => {
+    const plugin = constructPlugin(testRoute53Domain);
+    plugin.initializeVariables();
+
+    expect(plugin.route53.config.credentials.profile).to.equal(testRoute53Domain.route53Profile);
+    expect(plugin.route53.config.region).to.equal(testRoute53Domain.route53Region);
+    // expect(plugin.initialized).to.equal(true);
+  });
+});
 
 describe("Custom Domain Plugin", () => {
   it("Checks aws config", () => {

--- a/types.ts
+++ b/types.ts
@@ -23,12 +23,15 @@ export interface ServerlessInstance { // tslint:disable-line
                 hostedZoneId: string | undefined,
                 hostedZonePrivate: boolean | undefined,
                 enabled: boolean | string | undefined,
+                route53Profile: string | undefined;
+                route53Region: string | undefined;
             },
         },
     };
     providers: {
         aws: {
             sdk: {
+                SharedIniFileCredentials: any,
                 APIGateway: any,
                 Route53: any,
                 CloudFormation: any,


### PR DESCRIPTION
This is mostly a port of #90 to typescript. However, I also included a bugfix to handle accounts that have more than 100 domains in Route53. I simply wrapped the existing listHostedZones call in a do/while loop and check if the output is truncated and pass the Marker to the next list call.