### PR TITLE
Update serverless-domain-manager-deploy-policy.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.2.4] - 2019-06-24
+
+### Changed
+- Update the minimum required permissions to run the serverless domain manager plugin to include `apigateway:PATCH
+
 ## [3.2.3] - 2019-06-24
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "engines": {
     "node": ">=4.0"
   },

--- a/scripts/cloudformation/serverless-domain-manager-deploy-policy.yaml
+++ b/scripts/cloudformation/serverless-domain-manager-deploy-policy.yaml
@@ -31,8 +31,11 @@ Resources:
             Resource: !Sub arn:aws:apigateway:${AWS::Region}::/domainnames/*
           - Effect: Allow
             Action:
+              - apigateway:PATCH
               - apigateway:POST
-            Resource: !Sub arn:aws:apigateway:${AWS::Region}::/domainnames/*/basepathmappings
+            Resource:
+              - !Sub arn:aws:apigateway:${AWS::Region}::/domainnames/*/basepathmappings
+              - !Sub arn:aws:apigateway:${AWS::Region}::/domainnames/*/basepathmappings/*
           - Effect: Allow
             Action:
               - cloudfront:UpdateDistribution


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Potentially Fixes #210 and related issues.

**Description of Issue Fixed**
Update the minimum required permissions to run the serverless domain manager plugin to include `- apigateway:PATCH`.

**Changes proposed in this pull request**:

* Update serverless-domain-manager-deploy-policy.yaml
