### PR TITLE
setupBasePathMapping hook lifecycle configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ custom:
     certificateName: '*.foo.com'
     createRoute53Record: true
     endpointType: 'regional'
+    setupOnPackaging: false
 ```
 
 | Parameter Name | Default Value | Description |
@@ -83,6 +84,7 @@ custom:
 | hostedZoneId | | If hostedZoneId is set the route53 record set will be created in the matching zone, otherwise the hosted zone will be figured out from the domainName (hosted zone with matching domain). |
 | hostedZonePrivate | | If hostedZonePrivate is set to `true` then only private hosted zones will be used for route 53 records. If it is set to `false` then only public hosted zones will be used for route53 records. Setting this parameter is specially useful if you have multiple hosted zones with the same domain name (e.g. a public and a private one) |
 | enabled | true | Sometimes there are stages for which is not desired to have custom domain names. This flag allows the developer to disable the plugin for such cases. Accepts either `boolean` or `string` values and defaults to `true` for backwards compatibility. |
+| setupOnPackaging | false | Plugin modifies the Cloudformation template during the `after:deploy:deploy` serverless phase when setting up base path mapping. This may break compatibility with plugins that modify the template during hooks before `before:deploy`. Setting it to `true` will configure the plugin to fire during the `after:package:finalize` |
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ custom:
 | hostedZoneId | | If hostedZoneId is set the route53 record set will be created in the matching zone, otherwise the hosted zone will be figured out from the domainName (hosted zone with matching domain). |
 | hostedZonePrivate | | If hostedZonePrivate is set to `true` then only private hosted zones will be used for route 53 records. If it is set to `false` then only public hosted zones will be used for route53 records. Setting this parameter is specially useful if you have multiple hosted zones with the same domain name (e.g. a public and a private one) |
 | enabled | true | Sometimes there are stages for which is not desired to have custom domain names. This flag allows the developer to disable the plugin for such cases. Accepts either `boolean` or `string` values and defaults to `true` for backwards compatibility. |
-| setupOnPackaging | false | Plugin modifies the Cloudformation template during the `after:deploy:deploy` serverless phase when setting up base path mapping. This may break compatibility with plugins that modify the template during hooks before `before:deploy`. Setting it to `true` will configure the plugin to fire during the `after:package:finalize` |
+| setupOnPackaging | false | Plugin modifies the Cloudformation template during the `after:deploy:deploy` serverless phase when setting up base path mapping. This may break compatibility with plugins that modify the template during hooks before `after:deploy:deploy`. Setting it to `true` will configure the plugin to fire during the `after:package:finalize` |
 
 ## Running
 

--- a/index.ts
+++ b/index.ts
@@ -54,8 +54,10 @@ class ServerlessCustomDomain {
                 usage: "Deletes a domain using the domain name defined in the serverless file",
             },
         };
+        const setupOnPackaging = this.serverless.service.custom.customDomain.setupOnPackaging;
+        const hookName = !setupOnPackaging ? "after:deploy:deploy": "after:package:finalize";
         this.hooks = {
-            "before:package:finalize": this.hookWrapper.bind(this, this.setupBasePathMapping),
+            [hookName]: this.hookWrapper.bind(this, this.setupBasePathMapping),
             "after:info:info": this.hookWrapper.bind(this, this.domainSummary),
             "before:remove:remove": this.hookWrapper.bind(this, this.removeBasePathMapping),
             "create_domain:create": this.hookWrapper.bind(this, this.createDomain),

--- a/index.ts
+++ b/index.ts
@@ -55,7 +55,7 @@ class ServerlessCustomDomain {
             },
         };
         this.hooks = {
-            "after:deploy:deploy": this.hookWrapper.bind(this, this.setupBasePathMapping),
+            "before:package:finalize": this.hookWrapper.bind(this, this.setupBasePathMapping),
             "after:info:info": this.hookWrapper.bind(this, this.domainSummary),
             "before:remove:remove": this.hookWrapper.bind(this, this.removeBasePathMapping),
             "create_domain:create": this.hookWrapper.bind(this, this.createDomain),

--- a/index.ts
+++ b/index.ts
@@ -55,7 +55,7 @@ class ServerlessCustomDomain {
             },
         };
         const setupOnPackaging = this.serverless.service.custom.customDomain.setupOnPackaging;
-        const hookName = !setupOnPackaging ? "after:deploy:deploy": "after:package:finalize";
+        const hookName = !setupOnPackaging ? "after:deploy:deploy" : "after:package:finalize";
         this.hooks = {
             [hookName]: this.hookWrapper.bind(this, this.setupBasePathMapping),
             "after:info:info": this.hookWrapper.bind(this, this.domainSummary),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "3.1.0",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -67,6 +67,7 @@ const constructPlugin = (customDomainOptions) => {
           hostedZoneId: customDomainOptions.hostedZoneId,
           hostedZonePrivate: customDomainOptions.hostedZonePrivate,
           stage: customDomainOptions.stage,
+          setupOnPackaging: customDomainOptions.setupOnPackaging,
         },
       },
       provider: {
@@ -1121,6 +1122,23 @@ describe("Custom Domain Plugin", () => {
       consoleOutput = [];
     });
   });
+
+  describe("Hook Configuration", () => {
+    it("Should configure setUpBasePathMapping hook to after:deploy:deploy by default", async () => {
+      const plugin = constructPlugin({});
+      expect(plugin.hooks).to.have.property('after:deploy:deploy');
+    });
+
+    it("Should configure setUpBasePathMapping hook to after:deploy:deploy when passing a false parameter", async () => {
+      const plugin = constructPlugin({ setupOnPackaging: false });
+      expect(plugin.hooks).to.have.property('after:deploy:deploy');
+    });
+
+    it("Should configure setUpBasePathMapping hook to after:package:finalize when passing a true parameter", async () => {
+      const plugin = constructPlugin({ setupOnPackaging: true });
+      expect(plugin.hooks).to.have.property('after:package:finalize');
+    });
+  })
 
   describe("Missing plugin configuration", () => {
     it("Should thrown an Error when plugin customDomain configuration object is missing", () => {

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -66,8 +66,8 @@ const constructPlugin = (customDomainOptions) => {
           endpointType: customDomainOptions.endpointType,
           hostedZoneId: customDomainOptions.hostedZoneId,
           hostedZonePrivate: customDomainOptions.hostedZonePrivate,
-          stage: customDomainOptions.stage,
           setupOnPackaging: customDomainOptions.setupOnPackaging,
+          stage: customDomainOptions.stage,
         },
       },
       provider: {
@@ -1126,19 +1126,20 @@ describe("Custom Domain Plugin", () => {
   describe("Hook Configuration", () => {
     it("Should configure setUpBasePathMapping hook to after:deploy:deploy by default", async () => {
       const plugin = constructPlugin({});
-      expect(plugin.hooks).to.have.property('after:deploy:deploy');
+      expect(plugin.hooks).to.have.property("after:deploy:deploy");
     });
 
     it("Should configure setUpBasePathMapping hook to after:deploy:deploy when passing a false parameter", async () => {
       const plugin = constructPlugin({ setupOnPackaging: false });
-      expect(plugin.hooks).to.have.property('after:deploy:deploy');
+      expect(plugin.hooks).to.have.property("after:deploy:deploy");
     });
 
-    it("Should configure setUpBasePathMapping hook to after:package:finalize when passing a true parameter", async () => {
+    it("Should configure setUpBasePathMapping hook to after:package:finalize when passing a true parameter",
+    async () => {
       const plugin = constructPlugin({ setupOnPackaging: true });
-      expect(plugin.hooks).to.have.property('after:package:finalize');
+      expect(plugin.hooks).to.have.property("after:package:finalize");
     });
-  })
+  });
 
   describe("Missing plugin configuration", () => {
     it("Should thrown an Error when plugin customDomain configuration object is missing", () => {

--- a/types.ts
+++ b/types.ts
@@ -23,6 +23,7 @@ export interface ServerlessInstance { // tslint:disable-line
                 hostedZoneId: string | undefined,
                 hostedZonePrivate: boolean | undefined,
                 enabled: boolean | string | undefined,
+                setupOnPackaging: boolean | undefined,
             },
         },
     };


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #120

**Description of Issue Fixed**
Fixes integration with plugins that modify the cloudformation before `after:deploy:deploy` lifecyle hook.

**Changes proposed in this pull request**:

* Change 1
Adding setupOnPackaging in options to set setupBasePathMapping lifecycle hook. If true it will fire during `after:package:finalize`
```
custom:
  customDomain:
    setupOnPackaging: true
```