### PR TITLE
Move chai-spies and node types to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "3.1.0",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -147,12 +147,14 @@
     "@types/chai": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
-      "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA=="
+      "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
+      "dev": true
     },
     "@types/chai-spies": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/chai-spies/-/chai-spies-1.0.0.tgz",
       "integrity": "sha512-Bj/froHomMnlAPEYEeqhmSuNSjTWW/VuSvCVdhLdcb67+dy4ffjTR6fC0YYw9tHP6KR3U8fkF1mgzmzlChHc5Q==",
+      "dev": true,
       "requires": {
         "@types/chai": "*"
       }
@@ -164,9 +166,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.3.tgz",
-      "integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg=="
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.0.tgz",
+      "integrity": "sha512-Jrb/x3HT4PTJp6a4avhmJCDEVrPdqLfl3e8GGMbpkGGdwAV5UGlIs4vVEfsHHfylZVOKZWpOqmqFH8CbfOZ6kg==",
+      "dev": true
     },
     "abbrev": {
       "version": "1.0.9",
@@ -179,6 +182,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -881,7 +885,8 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1059,6 +1064,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -1090,7 +1096,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "make-error": {
       "version": "1.3.5",
@@ -1239,6 +1246,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -1563,7 +1571,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -1647,6 +1656,7 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -1693,7 +1703,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -1959,7 +1970,8 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",
@@ -2464,7 +2476,8 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "request": {
       "version": "2.88.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",
+    "@types/chai-spies": "^1.0.0",
     "@types/mocha": "^5.2.5",
+    "@types/node": "^12.0.0",
     "aws-sdk-mock": "^1.7.0",
     "chai": "^3.5.0",
     "chai-spies": "^1.0.0",
@@ -64,8 +66,6 @@
     "wrappy": "^1.0.2"
   },
   "dependencies": {
-    "@types/chai-spies": "^1.0.0",
-    "@types/node": "^11.11.3",
     "aws-sdk": "^2.177.0",
     "chalk": "^2.4.1"
   }


### PR DESCRIPTION
**Description of Issue Fixed**
By having `@types/chai-spies` in dependencies, every consumer of 'serverless-domain-manager ' is forced to get those types. Consequently, they get taken into consideration when you compile your code. However, `@types/chai-spies` is incompatible with `sinon-chai`. When trying to compile the project you get:
```
node_modules/@types/sinon-chai/index.d.ts:26:13 - error TS2717: Subsequent property declarations must have the same type.  Property 'called' must be of type 'Called', but here has type 'Assertion'.
```

**Changes proposed in this pull request**:
Moved `@types/chai-spies` to the `devDependencies` section of `package.json.` Took advantage to do the same with `@types/node.`
