### PR TITLE
Add more information to domain summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.2.6] - 2019-06-24
+
+### Added
+- Add hosted zone to domain summary
+
 ## [3.2.5] - 2019-06-24
 
 ### Added

--- a/index.ts
+++ b/index.ts
@@ -615,9 +615,8 @@ class ServerlessCustomDomain {
         }
 
         this.serverless.cli.consoleLog(chalk.yellow("Distribution Domain Name"));
-        this.serverless.cli.consoleLog(`  Target Domain: ${data.domainName}`);
-        this.serverless.cli.consoleLog(`  Hosted Zone Id: ${data.hostedZoneId}`);
-
+        this.serverless.cli.consoleLog(`  Target Domain: ${domainInfo.domainName}`);
+        this.serverless.cli.consoleLog(`  Hosted Zone Id: ${domainInfo.hostedZoneId}`);
     }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -615,7 +615,9 @@ class ServerlessCustomDomain {
         }
 
         this.serverless.cli.consoleLog(chalk.yellow("Distribution Domain Name"));
-        this.serverless.cli.consoleLog(`  ${domainInfo.domainName}`);
+        this.serverless.cli.consoleLog(`  Target Domain: ${data.domainName}`);
+        this.serverless.cli.consoleLog(`  Hosted Zone Id: ${data.hostedZoneId}`);
+
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
**Description of Issue Fixed**
Custom domain summary does not include the hosted zone of the domain.  This makes it difficult to create corresponding alias records in Route 53 without looking it up via CLI or AWS console.

**Changes proposed in this pull request**:
* Added hosted zone to domain summary