### PR TITLE
Add CreateServiceLinkedRole effect on cloudformation template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.2.5] - 2019-06-24
+
+### Added
+- Add `iam:CreateServiceLinkedRole` to CloudFormation template
+
 ## [3.2.4] - 2019-06-24
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "engines": {
     "node": ">=4.0"
   },

--- a/scripts/cloudformation/serverless-domain-manager-deploy-policy.yaml
+++ b/scripts/cloudformation/serverless-domain-manager-deploy-policy.yaml
@@ -51,3 +51,8 @@ Resources:
               - route53:GetHostedZone
               - route53:ListResourceRecordSets
             Resource: !Sub arn:aws:route53:::hostedzone/${HostedZoneId}
+          - Effect: Allow
+            Action:
+              - iam:CreateServiceLinkedRole
+            Resource:
+              - !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ops.apigateway.amazonaws.com/AWSServiceRoleForAPIGateway


### PR DESCRIPTION
**Description of Issue Fixed**
In your Readme you specify that the IAM deploying the lambda requires this permission:

- iam:CreateServiceLinkedRole

but this permission is not created in the cloudformation template you provide.

**Changes proposed in this pull request**:

* Add the relevant permission to the cloudformation template
