### PR TITLE
Increase Max Retries to 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.2.7] - 2019-08-02
+
+### Added
+- Add our own configuration for AWS SDK's built in retry mechanism, increasing it from per service default retries to 20 so that this plugin is more easily used in an automated environment.
+
 ## [3.2.6] - 2019-06-24
 
 ### Added

--- a/index.ts
+++ b/index.ts
@@ -170,6 +170,7 @@ class ServerlessCustomDomain {
         this.enabled = this.evaluateEnabled();
         if (this.enabled) {
             const credentials = this.serverless.providers.aws.getCredentials();
+            
             this.serverless.providers.aws.sdk.config.update({maxRetries: 20});
             this.apigateway = new this.serverless.providers.aws.sdk.APIGateway(credentials);
             this.route53 = new this.serverless.providers.aws.sdk.Route53(credentials);

--- a/index.ts
+++ b/index.ts
@@ -170,7 +170,7 @@ class ServerlessCustomDomain {
         this.enabled = this.evaluateEnabled();
         if (this.enabled) {
             const credentials = this.serverless.providers.aws.getCredentials();
-            
+              
             this.serverless.providers.aws.sdk.config.update({maxRetries: 20});
             this.apigateway = new this.serverless.providers.aws.sdk.APIGateway(credentials);
             this.route53 = new this.serverless.providers.aws.sdk.Route53(credentials);

--- a/index.ts
+++ b/index.ts
@@ -170,7 +170,7 @@ class ServerlessCustomDomain {
         this.enabled = this.evaluateEnabled();
         if (this.enabled) {
             const credentials = this.serverless.providers.aws.getCredentials();
-
+            this.serverless.providers.aws.sdk.config.update({maxRetries: 20});
             this.apigateway = new this.serverless.providers.aws.sdk.APIGateway(credentials);
             this.route53 = new this.serverless.providers.aws.sdk.Route53(credentials);
             this.cloudformation = new this.serverless.providers.aws.sdk.CloudFormation(credentials);

--- a/index.ts
+++ b/index.ts
@@ -170,7 +170,7 @@ class ServerlessCustomDomain {
         this.enabled = this.evaluateEnabled();
         if (this.enabled) {
             const credentials = this.serverless.providers.aws.getCredentials();
-              
+
             this.serverless.providers.aws.sdk.config.update({maxRetries: 20});
             this.apigateway = new this.serverless.providers.aws.sdk.APIGateway(credentials);
             this.route53 = new this.serverless.providers.aws.sdk.Route53(credentials);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1402,9 +1402,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.flattendeep": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "3.2.3",
+  "version": "3.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "engines": {
     "node": ">=4.0"
   },

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -52,7 +52,7 @@ const constructPlugin = (customDomainOptions) => {
           CloudFormation: aws.CloudFormation,
           Route53: aws.Route53,
           config: {
-            update: (toUpdate:object) => null
+            update: (toUpdate: object) => null,
           },
         },
       },

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -51,6 +51,9 @@ const constructPlugin = (customDomainOptions) => {
           APIGateway: aws.APIGateway,
           CloudFormation: aws.CloudFormation,
           Route53: aws.Route53,
+          config: {
+            update: (toUpdate:object) => null
+          },
         },
       },
     },

--- a/types.ts
+++ b/types.ts
@@ -34,8 +34,8 @@ export interface ServerlessInstance { // tslint:disable-line
                 CloudFormation: any,
                 ACM: any,
                 config: {
-                    update(toUpdate:object): void,
-                }
+                    update(toUpdate: object): void,
+                },
              }
             getCredentials(),
             getRegion(),

--- a/types.ts
+++ b/types.ts
@@ -35,11 +35,10 @@ export interface ServerlessInstance { // tslint:disable-line
                 ACM: any,
                 config: {
                     update(toUpdate:object): void,
-                },
-             },
+                }
+             }
             getCredentials(),
             getRegion(),
-            
         },
     };
     cli: {

--- a/types.ts
+++ b/types.ts
@@ -33,9 +33,13 @@ export interface ServerlessInstance { // tslint:disable-line
                 Route53: any,
                 CloudFormation: any,
                 ACM: any,
-            }
+                config: {
+                    update(toUpdate:object): void,
+                },
+             },
             getCredentials(),
             getRegion(),
+            
         },
     };
     cli: {


### PR DESCRIPTION
**Description of Issue Fixed**

Sometimes, the AWS commands this plugin uses timeout. When that happens,
the plugin currently fails out and the user must run the deploy again. That
is bad for automated environments where we want to run deploys seamlessly.
So let's add our own maxRetries to the AWS config object we get from
serverless and make sure that we retry throttled commands automatically.

**Changes proposed in this pull request**:

* Raises max retries to 20 retries
