### PR TITLE
Fix AWS SDK initialization after internal change in serverless

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -176,6 +176,7 @@ class ServerlessCustomDomain {
         this.enabled = this.evaluateEnabled();
         if (this.enabled) {
             const credentials = this.serverless.providers.aws.getCredentials();
+            credentials.region = this.serverless.providers.aws.getRegion();
 
             this.serverless.providers.aws.sdk.config.update({maxRetries: 20});
             this.apigateway = new this.serverless.providers.aws.sdk.APIGateway(credentials);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
Fix to comply with change introduced in v1.61.2

Fixes #306 

_Note that any internal and not publicly documented serverless API is considered private, and is subject to changes also in scope of patch releases._