### PR TITLE
Add support for HTTP and WebSocket API Types

### DIFF
--- a/DomainConfig.ts
+++ b/DomainConfig.ts
@@ -81,7 +81,7 @@ class DomainConfig {
      * If the property's value is provided, this should be boolean, otherwise an exception is thrown.
      * If no customDomain object exists, an exception is thrown.
      */
-    public evaluateEnabled(enabled: any): boolean {
+    private evaluateEnabled(enabled: any): boolean {
         // const enabled = this.serverless.service.custom.customDomain.enabled;
         if (enabled === undefined) {
             return true;

--- a/DomainConfig.ts
+++ b/DomainConfig.ts
@@ -1,0 +1,100 @@
+/**
+ * Wrapper class for Custom Domain information
+ */
+
+import Globals from "./Globals";
+import DomainInfo = require("./DomainInfo");
+import * as AWS from "aws-sdk"; // imported for Types
+
+class DomainConfig {
+
+    public givenDomainName: string;
+    public basePath: string | undefined;
+    public stage: string | undefined;
+    public certificateName: string | undefined;
+    public certificateArn: string | undefined;
+    public createRoute53Record: boolean | undefined;
+    public endpointType: string | undefined;
+    public apiType: string | undefined;
+    public hostedZoneId: string | undefined;
+    public hostedZonePrivate: boolean | undefined;
+    public enabled: boolean | string | undefined;
+    public securityPolicy: string | undefined;
+
+    public domainInfo: DomainInfo | undefined;
+    public apiId: string | undefined;
+    public apiMapping: AWS.ApiGatewayV2.GetApiMappingResponse;
+    public allowPathMatching: boolean | false;
+
+    constructor(config: any) {
+
+        this.enabled = this.evaluateEnabled(config.enabled);
+        this.givenDomainName = config.domainName;
+        this.hostedZonePrivate = config.hostedZonePrivate;
+        this.certificateArn = config.certificateArn;
+        this.certificateName = config.certificateName;
+        this.createRoute53Record = config.createRoute53Record;
+        this.hostedZoneId = config.hostedZoneId;
+        this.hostedZonePrivate = config.hostedZonePrivate;
+        this.allowPathMatching = config.allowPathMatching;
+
+        let basePath = config.basePath;
+        if (basePath == null || basePath.trim() === "") {
+            basePath = "(none)";
+        }
+        this.basePath = basePath;
+
+        let stage = config.stage;
+        if (typeof stage === "undefined") {
+            stage = Globals.options.stage || Globals.serverless.service.provider.stage;
+        }
+        this.stage = stage;
+
+        const endpointTypeWithDefault = config.endpointType || Globals.endpointTypes.edge;
+        const endpointTypeToUse = Globals.endpointTypes[endpointTypeWithDefault.toLowerCase()];
+        if (!endpointTypeToUse) {
+            throw new Error(`${endpointTypeWithDefault} is not supported endpointType, use edge or regional.`);
+        }
+        this.endpointType = endpointTypeToUse;
+
+        const apiTypeWithDefault =  config.apiType || Globals.apiTypes.rest;
+        const apiTypeToUse = Globals.apiTypes[apiTypeWithDefault.toLowerCase()];
+        if (!apiTypeToUse) {
+            throw new Error(`${apiTypeWithDefault} is not supported api type, use REST, HTTP or WEBSOCKET.`);
+        }
+        this.apiType = apiTypeToUse;
+
+        const securityPolicyDefault = config.securityPolicy || Globals.tlsVersions.tls_1_2;
+        const tlsVersionToUse = Globals.tlsVersions[securityPolicyDefault.toLowerCase()];
+        if (!tlsVersionToUse) {
+            throw new Error(`${securityPolicyDefault} is not a supported securityPolicy, use tls_1_0 or tls_1_2.`);
+        }
+        this.securityPolicy = tlsVersionToUse;
+    }
+
+    /**
+     * Determines whether this plug-in is enabled.
+     *
+     * This method reads the customDomain property "enabled" to see if this plug-in should be enabled.
+     * If the property's value is undefined, a default value of true is assumed (for backwards
+     * compatibility).
+     * If the property's value is provided, this should be boolean, otherwise an exception is thrown.
+     * If no customDomain object exists, an exception is thrown.
+     */
+    public evaluateEnabled(enabled: any): boolean {
+        // const enabled = this.serverless.service.custom.customDomain.enabled;
+        if (enabled === undefined) {
+            return true;
+        }
+        if (typeof enabled === "boolean") {
+            return enabled;
+        } else if (typeof enabled === "string" && enabled === "true") {
+            return true;
+        } else if (typeof enabled === "string" && enabled === "false") {
+            return false;
+        }
+        throw new Error(`serverless-domain-manager: Ambiguous enablement boolean: "${enabled}"`);
+    }
+}
+
+export = DomainConfig;

--- a/DomainInfo.ts
+++ b/DomainInfo.ts
@@ -18,11 +18,19 @@ class DomainInfo {
     private defaultSecurityPolicy: string = "TLS_1_2";
 
     constructor(data: any) {
-        this.domainName = data.distributionDomainName || data.regionalDomainName;
-        this.hostedZoneId = data.distributionHostedZoneId ||
-            data.regionalHostedZoneId ||
-            this.defaultHostedZoneId;
-        this.securityPolicy = data.securityPolicy || this.defaultSecurityPolicy;
+        this.domainName = data.distributionDomainName
+            || data.regionalDomainName
+            || data.DomainNameConfigurations && data.DomainNameConfigurations[0].ApiGatewayDomainName
+            || data.DomainName;
+
+        this.hostedZoneId = data.distributionHostedZoneId
+            || data.regionalHostedZoneId
+            || data.DomainNameConfigurations && data.DomainNameConfigurations[0].HostedZoneId
+            || this.defaultHostedZoneId;
+
+        this.securityPolicy = data.securityPolicy
+            || data.DomainNameConfigurations && data.DomainNameConfigurations[0].SecurityPolicy
+            || this.defaultSecurityPolicy;
     }
 }
 

--- a/Globals.ts
+++ b/Globals.ts
@@ -1,0 +1,23 @@
+import { ServerlessInstance, ServerlessOptions } from "./types";
+
+export default class Globals {
+
+    public static serverless: ServerlessInstance;
+    public static options: ServerlessOptions;
+
+    public static endpointTypes = {
+        edge: "EDGE",
+        regional: "REGIONAL",
+    };
+
+    public static apiTypes = {
+        http: "HTTP",
+        rest: "REST",
+        websocket: "WEBSOCKET",
+    };
+
+    public static tlsVersions = {
+        tls_1_0: "TLS_1_0",
+        tls_1_2: "TLS_1_2",
+    };
+}

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ plugins:
   - serverless-domain-manager
 ```
 
-Add the plugin configuration (example for `serverless.foo.com/api`). For a single domain and API type the following sturcture can be used.
+Add the plugin configuration (example for `serverless.foo.com/api`). For a single domain and API type the following structure can be used.
 
 ```yaml
 custom:
@@ -118,7 +118,7 @@ custom:
 | hostedZonePrivate | | If hostedZonePrivate is set to `true` then only private hosted zones will be used for route 53 records. If it is set to `false` then only public hosted zones will be used for route53 records. Setting this parameter is specially useful if you have multiple hosted zones with the same domain name (e.g. a public and a private one) |
 | enabled | true | Sometimes there are stages for which is not desired to have custom domain names. This flag allows the developer to disable the plugin for such cases. Accepts either `boolean` or `string` values and defaults to `true` for backwards compatibility. |
 securityPolicy | tls_1_2 | The security policy to apply to the custom domain name.  Accepts `tls_1_0` or `tls_1_2`|
-allowPathMatching | false | When updating an existing api mapping this will match on the basePath instead of the API ID to find existing mappings for an udpate. This should ony be used when changing API types. For example, migrating a REST API to an HTTP API. See Changing API Types for moe information.  |
+allowPathMatching | false | When updating an existing api mapping this will match on the basePath instead of the API ID to find existing mappings for an upsate. This should only be used when changing API types. For example, migrating a REST API to an HTTP API. See Changing API Types for more information.  |
 
 
 ## Running

--- a/index.ts
+++ b/index.ts
@@ -119,7 +119,7 @@ class ServerlessCustomDomain {
                     domain.domainInfo = undefined;
                     this.serverless.cli.log(`Custom domain ${domain.givenDomainName} was deleted.`);
                 } else {
-                    this.serverless.cli.log(`Custom domain ${domain.givenDomainName} does not exists.`);
+                    this.serverless.cli.log(`Custom domain ${domain.givenDomainName} does not exist.`);
                 }
             } catch (err) {
                 this.logIfDebug(err, domain.givenDomainName);
@@ -158,7 +158,6 @@ class ServerlessCustomDomain {
                 }
 
                 await this.getDomainInfo();
-                // this.addOutputs(domain);
 
             } catch (err) {
                 this.logIfDebug(err, domain.givenDomainName);
@@ -181,7 +180,7 @@ class ServerlessCustomDomain {
             try {
                 domain.apiId = await this.getApiId(domain);
 
-                // Unable to find the correspond API, manuall clean up will be required
+                // Unable to find the corresponding API, manual clean up will be required
                 if (!domain.apiId) {
                     this.serverless.cli.log(`Unable to find corresponding API for ${domain.givenDomainName},
                         API Mappings may need to be manually removed.`, "Serverless Domain Manager");
@@ -403,7 +402,7 @@ class ServerlessCustomDomain {
 
             // Make API call to create domain
             try {
-                // If creating REST api use v1 of api gateway, else use v2 for HTTP and Websocket
+                // Creating EDGE domain so use APIGateway (v1) service
                 createdDomain = await this.apigateway.createDomainName(params).promise();
                 domain.domainInfo = new DomainInfo(createdDomain);
             } catch (err) {
@@ -423,7 +422,7 @@ class ServerlessCustomDomain {
 
             // Make API call to create domain
             try {
-                // If creating REST api use v1 of api gateway, else use v2 for HTTP and Websocket
+                // Creating Regional domain so use ApiGatewayV2
                 createdDomain = await this.apigatewayV2.createDomainName(params).promise();
                 domain.domainInfo = new DomainInfo(createdDomain);
             } catch (err) {

--- a/index.ts
+++ b/index.ts
@@ -98,7 +98,7 @@ class ServerlessCustomDomain {
                 }
             } catch (err) {
                 this.logIfDebug(err, domain.givenDomainName);
-                throw new Error(`Error: Unable to craete domain ${domain.givenDomainName}`);
+                throw new Error(`Error: Unable to create domain ${domain.givenDomainName}`);
             }
         }));
     }
@@ -238,7 +238,7 @@ class ServerlessCustomDomain {
         this.route53 = new this.serverless.providers.aws.sdk.Route53(credentials);
         this.cloudformation = new this.serverless.providers.aws.sdk.CloudFormation(credentials);
 
-        // Loop over the domain configurations and popluates the domains array with DomainConfigs
+        // Loop over the domain configurations and populate the domains array with DomainConfigs
         this.domains = [];
 
         // If the key of the item in config is an api type it is using per api type domain structure
@@ -248,7 +248,7 @@ class ServerlessCustomDomain {
                     this.serverless.service.custom.customDomain[configApiType].apiType = configApiType;
                     this.domains.push(new DomainConfig(this.serverless.service.custom.customDomain[configApiType]));
                 } else {
-                    throw Error(`Error: Invalud API Type, ${configApiType}`);
+                    throw Error(`Error: Invalid API Type, ${configApiType}`);
                 }
             }
         } else { // Default to single domain config
@@ -266,7 +266,7 @@ class ServerlessCustomDomain {
             this.acm = new this.serverless.providers.aws.sdk.ACM(acmCredentials);
         }
 
-        // Validate the domain configuraitons
+        // Validate the domain configurations
         this.validateDomainConfigs();
     }
 
@@ -309,7 +309,7 @@ class ServerlessCustomDomain {
             return domain.certificateArn;
         }
 
-        let certificateArn; // The arn of the choosen certificate
+        let certificateArn; // The arn of the selected certificate
 
         let certificateName = domain.certificateName; // The certificate name
 

--- a/index.ts
+++ b/index.ts
@@ -194,7 +194,8 @@ class ServerlessCustomDomain {
                         API Mappings may need to be manually removed.`, "Serverless Domain Manager");
                 } else {
                     this.logIfDebug(err, domain.givenDomainName);
-                    throw new Error(`Error: Unable to remove base bath mappings for domain ${domain.givenDomainName}`);
+                    this.serverless.cli.log(`Error: Unable to remove base bath mappings
+                        for domain ${domain.givenDomainName}`);
                 }
             }
         }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -671,23 +671,28 @@
       }
     },
     "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.2.0",
+        "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
       }
     },
     "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
@@ -1032,9 +1037,9 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
     "hasha": {
@@ -1121,15 +1126,15 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
       "dev": true
     },
     "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -1145,12 +1150,12 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "^1.0.3"
       }
     },
     "is-stream": {
@@ -1160,12 +1165,12 @@
       "dev": true
     },
     "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-typedarray": {
@@ -1766,20 +1771,38 @@
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
     },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
     "object.entries": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
+      "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
       }
@@ -2368,6 +2391,26 @@
             "ansi-regex": "^4.1.0"
           }
         }
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "strip-ansi": {

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -337,8 +337,8 @@ describe("Custom Domain Plugin", () => {
 
       plugin.addOutputs(dc);
 
-      const cfTemplat = plugin.serverless.service.provider.compiledCloudFormationTemplate.Outputs;
-      expect(cfTemplat).to.not.equal(undefined);
+      const cfTemplate = plugin.serverless.service.provider.compiledCloudFormationTemplate.Outputs;
+      expect(cfTemplate).to.not.equal(undefined);
     });
 
     it("(none) is added if basepath is an empty string", async () => {

--- a/types.ts
+++ b/types.ts
@@ -20,6 +20,7 @@ export interface ServerlessInstance { // tslint:disable-line
                 certificateArn: string | undefined,
                 createRoute53Record: boolean | undefined,
                 endpointType: string | undefined,
+                apiType: string | undefined,
                 hostedZoneId: string | undefined,
                 hostedZonePrivate: boolean | undefined,
                 enabled: boolean | string | undefined,
@@ -31,6 +32,7 @@ export interface ServerlessInstance { // tslint:disable-line
         aws: {
             sdk: {
                 APIGateway: any,
+                ApiGatewayV2: any,
                 Route53: any,
                 CloudFormation: any,
                 ACM: any,


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #312 #207 #223  

**Description of Issue Fixed**
This PR adds support for both HTTP and Websocket API Types for the AWS API Gateway. For these types, domain names must use the ApiGatewayV2 AWS API.

This PR essentially bulkifies the entire process of defining and creating domains. Instead of config values being defined on variables in the index.ts file an array of DomainConfigs is created. Then for all operations it will process all of the domain configs. This allows the mixing of different API types and domains in one serverless.yml file. 

It is backward compatible with the current customdomain configuration format. It is also structured in a way that will easily scale should AWS add new API types in the future.

**This can be tested by adding the following branch to your dependencies.**
```
"dependencies": {
  "serverless-domain-manager": "tehnrd/serverless-domain-manager#http-ws-support-BETA"
},
```

**Changes proposed in this pull request**:

* Static global vars have been moved to Globals.ts to allow easy access across multiple files
* Domain configuration options have been removed from index.ts. A new class DomainConfig.ts is created from the plugin configuration. These are placed into an array of domains in index.ts.
* Methods that process many domain configurations at once like `createDomains()` have been bulkified to process all DomainConfigs in the `domains` array.
* Methods that process one domain at a time like `createCustomDomain()` now take an argument of a `DomainConfig`.
* The configuration is backward compatible but still supports new API types with apiType option. This works well for projects that have a single service per serverless.yml file
   ```yaml
    custom:
        customDomain:
            domainName: serverless.foo.com
            stage: ci
            basePath: api
            certificateName: '*.foo.com'
            createRoute53Record: true
            endpointType: 'regional'
            securityPolicy: tls_1_2
            apiType: rest
    ```
* A new configuration format is also added that allows defining multiple API types along with corrresponding domain configurations.
    ```yaml
    custom:
        customDomain:
            rest:
                domainName: rest.serverless.foo.com
                stage: ci
                basePath: api
                certificateName: '*.foo.com'
                createRoute53Record: true
                endpointType: 'regional'
                securityPolicy: tls_1_2
            http:
                domainName: http.serverless.foo.com
                stage: ci
                basePath: api
                certificateName: '*.foo.com'
                createRoute53Record: true
                endpointType: 'regional'
                securityPolicy: tls_1_2
            websocket:
                domainName: ws.serverless.foo.com
                stage: ci
                basePath: api
                certificateName: '*.foo.com'
                createRoute53Record: true
                endpointType: 'regional'
                securityPolicy: tls_1_2
    ```

Unit tests have been updated and a few new ones have been added. I also performed some functional testing and everything appears to be working. I was unable to get the integration tests to run but will try to work on that while this PR is pending review.

I understand this is a massive PR and a huge refactor but I would love to see this get some attention as it was a decent effort. Even being backward compatible it might be worth a 4.x release given potential impact and the number of people that have become dependent on this very popular package.

P.S. Can do normal online PR review, but I actually live and work near DUMBO and could do in-person walkthrough of the changes if that makes sense.