### PR TITLE
WIP: Add ability to specify tags - #254

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ custom:
     createRoute53Record: true
     endpointType: 'regional'
     securityPolicy: tls_1_2
+    tags:
+        project: foo
+        stage: ci
 ```
 
 | Parameter Name | Default Value | Description |
@@ -84,7 +87,8 @@ custom:
 | hostedZoneId | | If hostedZoneId is set the route53 record set will be created in the matching zone, otherwise the hosted zone will be figured out from the domainName (hosted zone with matching domain). |
 | hostedZonePrivate | | If hostedZonePrivate is set to `true` then only private hosted zones will be used for route 53 records. If it is set to `false` then only public hosted zones will be used for route53 records. Setting this parameter is specially useful if you have multiple hosted zones with the same domain name (e.g. a public and a private one) |
 | enabled | true | Sometimes there are stages for which is not desired to have custom domain names. This flag allows the developer to disable the plugin for such cases. Accepts either `boolean` or `string` values and defaults to `true` for backwards compatibility. |
-securityPolicy | tls_1_2 | The security policy to apply to the custom domain name.  Accepts `tls_1_0` or `tls_1_2`|
+| securityPolicy | tls_1_2 | The security policy to apply to the custom domain name.  Accepts `tls_1_0` or `tls_1_2`|
+| tags | | The domain name Tags (key-value map of strings). The valid character set is [a-zA-Z+-=._:/]. The tag key can be up to 128 characters and must not start with `aws:`. The tag value can be up to 256 characters. |
 
 ## Running
 

--- a/index.ts
+++ b/index.ts
@@ -36,6 +36,7 @@ class ServerlessCustomDomain {
     public givenDomainName: string;
     public hostedZonePrivate: boolean;
     public basePath: string;
+    public tags?: {};
     private endpointType: string;
     private stage: string;
     private securityPolicy: string;
@@ -212,6 +213,8 @@ class ServerlessCustomDomain {
             }
             this.endpointType = endpointTypeToUse;
 
+            this.tags = this.serverless.service.custom.customDomain.tags;
+
             const securityPolicyDefault = this.serverless.service.custom.customDomain.securityPolicy ||
                 tlsVersions.tls_1_2;
             const tlsVersionToUse = tlsVersions[securityPolicyDefault.toLowerCase()];
@@ -346,6 +349,7 @@ class ServerlessCustomDomain {
             },
             regionalCertificateArn: certificateArn,
             securityPolicy: this.securityPolicy,
+            tags: this.tags || {},
         };
         if (this.endpointType === endpointTypes.edge) {
             params.regionalCertificateArn = undefined;

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -71,6 +71,7 @@ const constructPlugin = (customDomainOptions) => {
           hostedZonePrivate: customDomainOptions.hostedZonePrivate,
           securityPolicy: customDomainOptions.securityPolicy,
           stage: customDomainOptions.stage,
+          tags: customDomainOptions.tags,
         },
       },
       provider: {
@@ -328,6 +329,21 @@ describe("Custom Domain Plugin", () => {
       });
 
       const plugin = constructPlugin({ domainName: "test_domain", securityPolicy: "tls_1_2"});
+      plugin.apigateway = new aws.APIGateway();
+      plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
+
+      const result = await plugin.createCustomDomain("fake_cert");
+
+      expect(result.domainName).to.equal("foo");
+      expect(result.securityPolicy).to.equal("TLS_1_2");
+    });
+
+    it("Create a domain name with tags", async () => {
+      AWS.mock("APIGateway", "createDomainName", (params, callback) => {
+        callback(null, { distributionDomainName: "foo", securityPolicy: "TLS_1_2"});
+      });
+
+      const plugin = constructPlugin({ domainName: "test_domain", tags: {foo: "bar"}});
       plugin.apigateway = new aws.APIGateway();
       plugin.givenDomainName = plugin.serverless.service.custom.customDomain.domainName;
 

--- a/types.ts
+++ b/types.ts
@@ -24,6 +24,7 @@ export interface ServerlessInstance { // tslint:disable-line
                 hostedZonePrivate: boolean | undefined,
                 enabled: boolean | string | undefined,
                 securityPolicy: string | undefined,
+                tags: object | undefined,
             },
         },
     };


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #254 

**Description of Issue Fixed**
Missing ability to specify custom domain tags.

```
custom:
  customDomain:
    domainName: foo.example.tld
    tags:
      Owner: myowner
      Environment: myenv
      Department: mydept
```

**Changes proposed in this pull request**:

* Add ability to specify tags

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->
