### PR TITLE
Add utility function for doing paging and use it for ACM certs and API mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - 2020-05-15
+
+### Changed
+- Fixed issue when there are multiple pages of base path mappings. Also refactored how paging is handled throughout the code. Thanks @kzhou57 for discovering this ([#345](https://github.com/amplify-education/serverless-domain-manager/pull/345))
+
 ## [4.0.1] - 2020-05-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [4.1.0] - 2020-05-15
+## [4.1.0] - 2020-05-18
 
 ### Changed
 - Fixed issue when there are multiple pages of base path mappings. Also refactored how paging is handled throughout the code. Thanks @kzhou57 for discovering this ([#345](https://github.com/amplify-education/serverless-domain-manager/pull/345))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "engines": {
     "node": ">=4.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -775,19 +775,6 @@ class ServerlessCustomDomain {
     }
 
     /**
-     * Prints out a summary of all domain manager related info
-     */
-
-    private printDomainSummary(domain: DomainConfig): void {
-        this.serverless.cli.consoleLog(chalk.yellow.underline("\nServerless Domain Manager Summary"));
-
-        this.serverless.cli.consoleLog(chalk.yellow("Distribution Domain Name"));
-        this.serverless.cli.consoleLog(`  Domain Name: ${domain.givenDomainName}`);
-        this.serverless.cli.consoleLog(`  Target Domain: ${domain.domainInfo.domainName}`);
-        this.serverless.cli.consoleLog(`  Hosted Zone Id: ${domain.domainInfo.hostedZoneId}`);
-    }
-
-    /**
      * Iterate through the pages of a AWS SDK response and collect them into a single array
      *
      * @param service - The AWS service instance to use to make the calls
@@ -797,7 +784,7 @@ class ServerlessCustomDomain {
      * @param nextRequestTokenKey - The response key name that has the next paging token value
      * @param params - Parameters to send in the request
      */
-    private async getAWSPagedResults(
+    public async getAWSPagedResults(
         service: Service,
         funcName: string,
         resultsKey: string,
@@ -814,6 +801,19 @@ class ServerlessCustomDomain {
             results = results.concat(response[resultsKey]);
         }
         return results;
+    }
+
+    /**
+     * Prints out a summary of all domain manager related info
+     */
+
+    private printDomainSummary(domain: DomainConfig): void {
+        this.serverless.cli.consoleLog(chalk.yellow.underline("\nServerless Domain Manager Summary"));
+
+        this.serverless.cli.consoleLog(chalk.yellow("Distribution Domain Name"));
+        this.serverless.cli.consoleLog(`  Domain Name: ${domain.givenDomainName}`);
+        this.serverless.cli.consoleLog(`  Target Domain: ${domain.domainInfo.domainName}`);
+        this.serverless.cli.consoleLog(`  Hosted Zone Id: ${domain.domainInfo.hostedZoneId}`);
     }
 }
 

--- a/test/integration-tests/test-utilities.ts
+++ b/test/integration-tests/test-utilities.ts
@@ -56,52 +56,40 @@ async function createTempDir(tempDir, folderName) {
 /**
  * Gets endpoint type of given URL from AWS
  * @param url
- * @returns {Promise<String|null>} Resolves to String if endpoint exists, else null.
+ * @returns {Promise<String>}
  */
 async function getEndpointType(url) {
-  const params = {
+  const result = await apiGateway.getDomainName({
     domainName: url,
-  };
-  try {
-    const result = await apiGateway.getDomainName(params).promise();
-    return result.endpointConfiguration.types[0];
-  } catch (err) {
-    return null;
-  }
+  }).promise();
+
+  return result.endpointConfiguration.types[0];
 }
 
 /**
  * Gets stage of given URL from AWS
  * @param url
- * @returns {Promise<String|null>} Resolves to String if stage exists, else null.
+ * @returns {Promise<String>}
  */
 async function getStage(url) {
-  const params = {
+  const result = await apiGateway.getBasePathMappings({
     domainName: url,
-  };
-  try {
-    const result = await apiGateway.getBasePathMappings(params).promise();
-    return result.items[0].stage;
-  } catch (err) {
-    return null;
-  }
+  }).promise();
+
+  return result.items[0].stage;
 }
 
 /**
  * Gets basePath of given URL from AWS
  * @param url
- * @returns {Promise<String|null>} Resolves to String if basePath exists, else null.
+ * @returns {Promise<String>}
  */
 async function getBasePath(url) {
-  const params = {
+  const result = await apiGateway.getBasePathMappings({
     domainName: url,
-  };
-  try {
-    const result = await apiGateway.getBasePathMappings(params).promise();
-    return result.items[0].basePath;
-  } catch (err) {
-    return null;
-  }
+  }).promise();
+
+  return result.items[0].basePath;
 }
 
 /**

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -1478,4 +1478,39 @@ describe("Custom Domain Plugin", () => {
       consoleOutput = [];
     });
   });
+
+  describe("AWS paged results", () => {
+    it("Should combine paged results into a list", async () => {
+      let callCount = 0;
+      const responses = [{
+        Items: ["a", "b"],
+        NextToken: "1",
+      },
+      {
+        Items: ["c", "d"],
+        NextToken: "2",
+      },
+      {
+        Items: ["e"],
+      },
+      {
+        Items: ["f"], // this call should never happen since its after the last request that included a token
+      }];
+      AWS.mock("ApiGatewayV2", "getApiMappings", (params, callback) => {
+        callback(null, responses[callCount++]);
+      });
+
+      const plugin = constructPlugin({});
+      const results = await plugin.getAWSPagedResults(
+          new aws.ApiGatewayV2(),
+          "getApiMappings",
+          "Items",
+          "NextToken",
+          "NextToken",
+          { DomainName: "example.com"},
+      );
+      expect(results).to.deep.equal([ "a", "b", "c", "d", "e" ]);
+      AWS.restore();
+    });
+  });
 });

--- a/test/unit-tests/tslint.json
+++ b/test/unit-tests/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "tslint:recommended"
-}


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #330

**Description of Issue Fixed**
This is an alternative to #331. I've pulled out the paging logic into its own function so we can reuse it for other things.

**Changes proposed in this pull request**:

* Add utility function for paging any type of AWS request
* Use the paging utility function to page the results of the ACM certs and API mappings requests

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->
