### PR TITLE
Add throttledCall function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 "use strict";
 
-import {Service} from "aws-sdk";
 import chalk from "chalk";
 import DomainConfig = require("./DomainConfig");
 import DomainInfo = require("./DomainInfo");
 import Globals from "./Globals";
 import { ServerlessInstance, ServerlessOptions } from "./types";
+import {getAWSPagedResults, throttledCall} from "./utils";
 
 const certStatuses = ["PENDING_VALIDATION", "ISSUED", "INACTIVE"];
 
@@ -234,7 +234,6 @@ class ServerlessCustomDomain {
         const credentials = this.serverless.providers.aws.getCredentials();
         credentials.region = this.serverless.providers.aws.getRegion();
 
-        this.serverless.providers.aws.sdk.config.update({ maxRetries: 20 });
         this.apigateway = new this.serverless.providers.aws.sdk.APIGateway(credentials);
         this.apigatewayV2 = new this.serverless.providers.aws.sdk.ApiGatewayV2(credentials);
         this.route53 = new this.serverless.providers.aws.sdk.Route53(credentials);
@@ -316,7 +315,7 @@ class ServerlessCustomDomain {
         let certificateName = domain.certificateName; // The certificate name
 
         try {
-            const certificates = await this.getAWSPagedResults(
+            const certificates = await getAWSPagedResults(
                 this.acm,
                 "listCertificates",
                 "CertificateSummaryList",
@@ -368,9 +367,9 @@ class ServerlessCustomDomain {
     public async getDomainInfo(): Promise<void> {
         await Promise.all(this.domains.map(async (domain) => {
             try {
-                const domainInfo = await this.apigatewayV2.getDomainName({
+                const domainInfo = await throttledCall(this.apigatewayV2, "getDomainName", {
                     DomainName: domain.givenDomainName,
-                }).promise();
+                });
 
                 domain.domainInfo = new DomainInfo(domainInfo);
             } catch (err) {
@@ -412,7 +411,7 @@ class ServerlessCustomDomain {
             // Make API call to create domain
             try {
                 // Creating EDGE domain so use APIGateway (v1) service
-                createdDomain = await this.apigateway.createDomainName(params).promise();
+                createdDomain = await throttledCall(this.apigateway, "createDomainName", params);
                 domain.domainInfo = new DomainInfo(createdDomain);
             } catch (err) {
                 this.logIfDebug(err, domain.givenDomainName);
@@ -432,7 +431,7 @@ class ServerlessCustomDomain {
             // Make API call to create domain
             try {
                 // Creating Regional domain so use ApiGatewayV2
-                createdDomain = await this.apigatewayV2.createDomainName(params).promise();
+                createdDomain = await throttledCall(this.apigatewayV2, "createDomainName", params);
                 domain.domainInfo = new DomainInfo(createdDomain);
             } catch (err) {
                 this.logIfDebug(err, domain.givenDomainName);
@@ -447,7 +446,9 @@ class ServerlessCustomDomain {
     public async deleteCustomDomain(domain: DomainConfig): Promise<void> {
         // Make API call
         try {
-            await this.apigatewayV2.deleteDomainName({DomainName: domain.givenDomainName}).promise();
+            await throttledCall(this.apigatewayV2, "deleteDomainName", {
+                DomainName: domain.givenDomainName,
+            });
         } catch (err) {
             this.logIfDebug(err, domain.givenDomainName);
             throw new Error(`Error: Failed to delete custom domain ${domain.givenDomainName}\n`);
@@ -493,7 +494,7 @@ class ServerlessCustomDomain {
         };
         // Make API call
         try {
-            await this.route53.changeResourceRecordSets(params).promise();
+            await throttledCall(this.route53, "changeResourceRecordSets", params);
         } catch (err) {
             this.logIfDebug(err, domain.givenDomainName);
             throw new Error(`Error: Failed to ${action} A Alias for ${domain.givenDomainName}\n`);
@@ -521,7 +522,7 @@ class ServerlessCustomDomain {
         const givenDomainNameReverse = domain.givenDomainName.split(".").reverse();
 
         try {
-            hostedZoneData = await this.route53.listHostedZones({}).promise();
+            hostedZoneData = await throttledCall(this.route53, "listHostedZones", {});
             const targetHostedZone = hostedZoneData.HostedZones
                 .filter((hostedZone) => {
                     let hostedZoneName;
@@ -564,7 +565,7 @@ class ServerlessCustomDomain {
 
     public async getBasePathMapping(domain: DomainConfig): Promise<AWS.ApiGatewayV2.GetApiMappingResponse> {
         try {
-            const mappings = await this.getAWSPagedResults(
+            const mappings = await getAWSPagedResults(
                 this.apigatewayV2,
                 "getApiMappings",
                 "Items",
@@ -598,7 +599,7 @@ class ServerlessCustomDomain {
             };
             // Make API call
             try {
-                await this.apigateway.createBasePathMapping(params).promise();
+                await throttledCall(this.apigateway, "createBasePathMapping", params);
                 this.serverless.cli.log(`Created API mapping '${domain.basePath}' for ${domain.givenDomainName}`);
             } catch (err) {
                 this.logIfDebug(err, domain.givenDomainName);
@@ -614,7 +615,7 @@ class ServerlessCustomDomain {
             };
             // Make API call
             try {
-                await this.apigatewayV2.createApiMapping(params).promise();
+                await throttledCall(this.apigatewayV2, "createApiMapping", params);
                 this.serverless.cli.log(`Created API mapping '${domain.basePath}' for ${domain.givenDomainName}`);
             } catch (err) {
                 this.logIfDebug(err, domain.givenDomainName);
@@ -646,7 +647,7 @@ class ServerlessCustomDomain {
 
             // Make API call
             try {
-                await this.apigateway.updateBasePathMapping(params).promise();
+                await throttledCall(this.apigateway, "updateBasePathMapping", params);
                 this.serverless.cli.log(`Updated API mapping from '${domain.apiMapping.ApiMappingKey}'
                      to '${domain.basePath}' for ${domain.givenDomainName}`);
             } catch (err) {
@@ -666,7 +667,7 @@ class ServerlessCustomDomain {
 
             // Make API call
             try {
-                await this.apigatewayV2.updateApiMapping(params).promise();
+                await throttledCall(this.apigatewayV2, "updateApiMapping", params);
                 this.serverless.cli.log(`Updated API mapping to '${domain.basePath}' for ${domain.givenDomainName}`);
             } catch (err) {
                 this.logIfDebug(err, domain.givenDomainName);
@@ -702,7 +703,7 @@ class ServerlessCustomDomain {
 
         let response;
         try {
-            response = await this.cloudformation.describeStackResource(params).promise();
+            response = await throttledCall(this.cloudformation, "describeStackResource", params);
         } catch (err) {
             this.logIfDebug(err, domain.givenDomainName);
             throw new Error(`Error: Failed to find CloudFormation resources for ${domain.givenDomainName}\n`);
@@ -726,7 +727,7 @@ class ServerlessCustomDomain {
 
         // Make API call
         try {
-            await this.apigatewayV2.deleteApiMapping(params).promise();
+            await throttledCall(this.apigatewayV2, "deleteApiMapping", params);
             this.serverless.cli.log("Removed basepath mapping.");
         } catch (err) {
             this.logIfDebug(err, domain.givenDomainName);
@@ -782,35 +783,6 @@ class ServerlessCustomDomain {
         if (process.env.SLS_DEBUG) {
             this.serverless.cli.log(`Error: ${domain ? domain + ": " : ""} ${message}`, "Serverless Domain Manager");
         }
-    }
-
-    /**
-     * Iterate through the pages of a AWS SDK response and collect them into a single array
-     *
-     * @param service - The AWS service instance to use to make the calls
-     * @param funcName - The function name in the service to call
-     * @param resultsKey - The key name in the response that contains the items to return
-     * @param nextTokenKey - The request key name to append to the request that has the paging token value
-     * @param nextRequestTokenKey - The response key name that has the next paging token value
-     * @param params - Parameters to send in the request
-     */
-    public async getAWSPagedResults(
-        service: Service,
-        funcName: string,
-        resultsKey: string,
-        nextTokenKey: string,
-        nextRequestTokenKey: string,
-        params: object,
-    ): Promise<any[]> {
-        let results = [];
-        let response = await service[funcName](params).promise();
-        results = results.concat(response[resultsKey]);
-        while (response.hasOwnProperty(nextRequestTokenKey) && response[nextRequestTokenKey]) {
-            params[nextTokenKey] = response[nextRequestTokenKey];
-            response = await service[funcName](params).promise();
-            results = results.concat(response[resultsKey]);
-        }
-        return results;
     }
 
     /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,81 @@
+import {Service} from "aws-sdk";
+
+const RETRYABLE_ERRORS = ["Throttling", "RequestLimitExceeded", "TooManyRequestsException"];
+
+/**
+ * Iterate through the pages of a AWS SDK response and collect them into a single array
+ *
+ * @param service - The AWS service instance to use to make the calls
+ * @param funcName - The function name in the service to call
+ * @param resultsKey - The key name in the response that contains the items to return
+ * @param nextTokenKey - The request key name to append to the request that has the paging token value
+ * @param nextRequestTokenKey - The response key name that has the next paging token value
+ * @param params - Parameters to send in the request
+ */
+async function getAWSPagedResults(
+    service: Service,
+    funcName: string,
+    resultsKey: string,
+    nextTokenKey: string,
+    nextRequestTokenKey: string,
+    params: object,
+): Promise<any[]> {
+    let results = [];
+    let response = await throttledCall(service, funcName, params);
+    results = results.concat(response[resultsKey]);
+    while (response.hasOwnProperty(nextRequestTokenKey) && response[nextRequestTokenKey]) {
+        params[nextTokenKey] = response[nextRequestTokenKey];
+        response = await service[funcName](params).promise();
+        results = results.concat(response[resultsKey]);
+    }
+    return results;
+}
+
+async function throttledCall(service: Service, funcName: string, params: object): Promise<any> {
+    const maxTimePassed = 5 * 60;
+
+    let timePassed = 0;
+    let previousInterval = 0;
+
+    const minWait = 3;
+    const maxWait = 60;
+
+    while (true) {
+        try {
+            return await service[funcName](params).promise();
+        } catch (ex) {
+            // rethrow the exception if it is not a type of retryable exception
+            if (RETRYABLE_ERRORS.indexOf(ex.code) === -1) {
+                throw ex;
+            }
+
+            // rethrow the exception if we have waited too long
+            if (timePassed >= maxTimePassed) {
+                throw ex;
+            }
+
+            // Sleep using the Decorrelated Jitter algorithm recommended by AWS
+            // https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+            let newInterval = Math.random() * Math.min(maxWait, previousInterval * 3);
+            newInterval = Math.max(minWait, newInterval);
+
+            await sleep(newInterval);
+            previousInterval = newInterval;
+            timePassed += previousInterval;
+        }
+    }
+}
+
+/**
+ * Stops event thread execution for given number of seconds.
+ * @param seconds
+ * @returns {Promise<void>} Resolves after given number of seconds.
+ */
+async function sleep(seconds) {
+    return new Promise((resolve) => setTimeout(resolve, 1000 * seconds));
+}
+
+export {
+    getAWSPagedResults,
+    throttledCall,
+};

--- a/test/integration-tests/integration.test.ts
+++ b/test/integration-tests/integration.test.ts
@@ -129,17 +129,12 @@ describe("Integration Tests", function() {
       const testName = "null-basepath-mapping";
       const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
       // Perform sequence of commands to replicate basepath mapping issue
-      // Sleep for half a min between commands in order to avoid rate limiting.
       try {
         await utilities.createTempDir(TEMP_DIR, testName);
         await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsDeleteDomain(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
 
         const basePath = await utilities.getBasePath(testURL);
@@ -153,17 +148,12 @@ describe("Integration Tests", function() {
       const testName = "basepath-mapping";
       const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
       // Perform sequence of commands to replicate basepath mapping issue
-      // Sleep for half a min between commands in order to avoid rate limiting.
       try {
         await utilities.createTempDir(TEMP_DIR, testName);
         await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsDeleteDomain(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
 
         const basePath = await utilities.getBasePath(testURL);
@@ -177,19 +167,13 @@ describe("Integration Tests", function() {
       const testName = "null-basepath-mapping";
       const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
       // Perform sequence of commands to replicate basepath mapping issue
-      // Sleep for half a min between commands in order to avoid rate limiting.
       try {
         await utilities.createTempDir(TEMP_DIR, testName);
         await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsDeleteDomain(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsRemove(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
 
         const basePath = await utilities.getBasePath(testURL);
@@ -207,11 +191,8 @@ describe("Integration Tests", function() {
       try {
         await utilities.createTempDir(TEMP_DIR, testName);
         await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
       } finally {
         await utilities.destroyResources(testURL, RANDOM_STRING);
@@ -224,11 +205,8 @@ describe("Integration Tests", function() {
       try {
         await utilities.createTempDir(TEMP_DIR, testName);
         await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
-        await utilities.sleep(30);
         await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
       } finally {
         await utilities.destroyResources(testURL, RANDOM_STRING);

--- a/test/integration-tests/test-utilities.ts
+++ b/test/integration-tests/test-utilities.ts
@@ -12,15 +12,6 @@ const apiGateway = new aws.APIGateway({
 });
 
 /**
- * Stops event thread execution for given number of seconds.
- * @param seconds
- * @returns {Promise<void>} Resolves after given number of seconds.
- */
-async function sleep(seconds) {
-  return new Promise((resolve) => setTimeout(resolve, 1000 * seconds));
-}
-
-/**
  * Executes given shell command.
  * @param cmd shell command to execute
  * @returns {Promise<void>} Resolves if successfully executed, else rejects
@@ -230,7 +221,6 @@ export {
   getEndpointType,
   getBasePath,
   getStage,
-  sleep,
   setupApiGatewayResources,
   deleteApiGatewayResources,
 };

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -7,6 +7,7 @@ import DomainConfig = require("../../src/DomainConfig");
 import DomainInfo = require("../../src/DomainInfo");
 import Globals from "../../src/Globals";
 import ServerlessCustomDomain = require("../../src/index");
+import {getAWSPagedResults} from "../../src/utils";
 
 const expect = chai.expect;
 chai.use(spies);
@@ -1563,7 +1564,7 @@ describe("Custom Domain Plugin", () => {
       });
 
       const plugin = constructPlugin({});
-      const results = await plugin.getAWSPagedResults(
+      const results = await getAWSPagedResults(
           new aws.ApiGatewayV2(),
           "getApiMappings",
           "Items",


### PR DESCRIPTION
Switch to using a custom backoff function instead of depending on the built in backoff in the AWS client.
This allows us to retry for only certain types of exceptions and increase the number of times it retries
to avoid getting throttle errors


**Changes proposed in this pull request**:

* Add throttledCall function
* Change all AWS SDK calls to use throttledCall
* Reset the AWS SDK retry config back to default now that we are handling it ourselves
* Update tests

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->
