### PR TITLE
add autoDomain and autoDomainWaitFor option to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ custom:
       createRoute53Record: true
       endpointType: 'regional'
       securityPolicy: tls_1_2
-      autoDomain: false
     http:
       domainName: http.serverless.foo.com
       stage: ci
@@ -96,7 +95,6 @@ custom:
       createRoute53Record: true
       endpointType: 'regional'
       securityPolicy: tls_1_2
-      autoDomain: false
     websocket:
       domainName: ws.serverless.foo.com
       stage: ci
@@ -105,7 +103,6 @@ custom:
       createRoute53Record: true
       endpointType: 'regional'
       securityPolicy: tls_1_2
-      autoDomain: false
 ```
 
 | Parameter Name | Default Value | Description |

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ custom:
     endpointType: 'regional'
     securityPolicy: tls_1_2
     apiType: rest
+    autoDomain: false
 ```
 
 Multiple API types mapped to different domains can also be supported with the following structure. The key is the API Gateway API type.
@@ -86,6 +87,7 @@ custom:
       createRoute53Record: true
       endpointType: 'regional'
       securityPolicy: tls_1_2
+      autoDomain: false
     http:
       domainName: http.serverless.foo.com
       stage: ci
@@ -94,6 +96,7 @@ custom:
       createRoute53Record: true
       endpointType: 'regional'
       securityPolicy: tls_1_2
+      autoDomain: false
     websocket:
       domainName: ws.serverless.foo.com
       stage: ci
@@ -102,6 +105,7 @@ custom:
       createRoute53Record: true
       endpointType: 'regional'
       securityPolicy: tls_1_2
+      autoDomain: false
 ```
 
 | Parameter Name | Default Value | Description |
@@ -119,6 +123,8 @@ custom:
 | enabled | true | Sometimes there are stages for which is not desired to have custom domain names. This flag allows the developer to disable the plugin for such cases. Accepts either `boolean` or `string` values and defaults to `true` for backwards compatibility. |
 securityPolicy | tls_1_2 | The security policy to apply to the custom domain name.  Accepts `tls_1_0` or `tls_1_2`|
 allowPathMatching | false | When updating an existing api mapping this will match on the basePath instead of the API ID to find existing mappings for an upsate. This should only be used when changing API types. For example, migrating a REST API to an HTTP API. See Changing API Types for more information.  |
+| autoDomain | `false` | Toggles whether or not the plugin will run `create_domain/delete_domain` as part of `sls deploy/remove` so that multiple commands are not required. |
+| autoDomainWaitFor | `120` | How long to wait for create_domain to finish before starting deployment if domain does not exist immediately. |
 
 
 ## Running

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,8 @@ export interface ServerlessInstance { // tslint:disable-line
                 hostedZonePrivate: boolean | undefined,
                 enabled: boolean | string | undefined,
                 securityPolicy: string | undefined,
+                autoDomain: boolean | undefined,
+                autoDomainWaitFor: string | undefined,
             },
         },
     };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,6 +76,7 @@ async function sleep(seconds) {
 }
 
 export {
+    sleep,
     getAWSPagedResults,
     throttledCall,
 };

--- a/test/integration-tests/auto-domain/handler.js
+++ b/test/integration-tests/auto-domain/handler.js
@@ -1,0 +1,16 @@
+"use strict";
+
+module.exports.helloWorld = (event, context, callback) => {
+  const response = {
+    statusCode: 200,
+    headers: {
+      "Access-Control-Allow-Origin": "*", // Required for CORS support to work
+    },
+    body: JSON.stringify({
+      message: "Go Serverless v1.0! Your function executed successfully!",
+      input: event,
+    }),
+  };
+
+  callback(null, response);
+};

--- a/test/integration-tests/auto-domain/serverless.yml
+++ b/test/integration-tests/auto-domain/serverless.yml
@@ -1,0 +1,27 @@
+# Deploying should be idempotent
+service: auto-domain-${opt:RANDOM_STRING}
+provider:
+  name: aws
+  runtime: nodejs12.x
+  region: us-west-2
+  stage: test
+functions:
+  helloWorld:
+    handler: handler.helloWorld
+    events:
+      - http:
+          path: hello-world
+          method: get
+          cors: true
+plugins:
+  - serverless-domain-manager
+custom:
+  customDomain:
+    domainName: auto-domain-${opt:RANDOM_STRING}.${env:TEST_DOMAIN}
+    basePath: ''
+    autoDomain: true
+    autoDomainWaitFor: 120
+
+package:
+  exclude:
+    - node_modules/**

--- a/test/integration-tests/auto-domain/serverless.yml
+++ b/test/integration-tests/auto-domain/serverless.yml
@@ -1,4 +1,4 @@
-# Deploying should be idempotent
+# create_domain should be run as part of deployment
 service: auto-domain-${opt:RANDOM_STRING}
 provider:
   name: aws

--- a/test/integration-tests/integration.test.ts
+++ b/test/integration-tests/integration.test.ts
@@ -23,6 +23,14 @@ const TEMP_DIR = `~/tmp/domain-manager-test-${RANDOM_STRING}`;
 const testCases = [
   {
     testBasePath: "(none)",
+    testDescription: "Creates domain as part of deploy",
+    testDomain: `auto-domain-${RANDOM_STRING}.${TEST_DOMAIN}`,
+    testEndpoint: "EDGE",
+    testFolder: "auto-domain",
+    testStage: "dev",
+  },
+  {
+    testBasePath: "(none)",
     testDescription: "Enabled with default values",
     testDomain: `enabled-default-${RANDOM_STRING}.${TEST_DOMAIN}`,
     testEndpoint: "EDGE",


### PR DESCRIPTION
addressed feedback on https://github.com/amplify-education/serverless-domain-manager/pull/323

**Changes proposed in this pull request**:

* Adds `autoDomain` and `autoDomainWaitFor` option to customDomain config

This will enable the creation/deletion of a domain name to be run as part of `sls deploy` and `sls remove`.

This will be an option to eliminate the need to call `sls create_domain` prior to `sls deploy` if you'd like to only run `sls deploy` across all of your stacks and do not want to run an additional pre-command.

Due to eventual consistency, `autoDomainWaitFor` option is defaulted to 120 seconds but it should only ever have to wait on the first time it is created.
