### PR TITLE
Hotfix/get cert arn wildcard fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -330,7 +330,14 @@ class ServerlessCustomDomain {
             // Checks if a certificate name is given
             if (certificateName != null) {
                 const foundCertificate = certificates
-                    .find((certificate) => (certificate.DomainName === certificateName));
+                  .find((certificate) => {
+                    // Looks for wild card and takes out wildcard and '.' when checking
+                    // '*.example.tld' => 'example.tld'
+                    if (certificateName[0] === "*") {
+                      certificateName = certificateName.substr(2);
+                    }
+                    return certificate.DomainName === certificateName
+                  });
                 if (foundCertificate != null) {
                     certificateArn = foundCertificate.CertificateArn;
                 }

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -8,6 +8,7 @@ import DomainInfo = require("../../src/DomainInfo");
 import Globals from "../../src/Globals";
 import ServerlessCustomDomain = require("../../src/index");
 import {getAWSPagedResults} from "../../src/utils";
+import { Domain } from "domain";
 
 const expect = chai.expect;
 chai.use(spies);
@@ -545,6 +546,22 @@ describe("Custom Domain Plugin", () => {
       const result = await plugin.getCertArn(dc);
 
       expect(result).to.equal("test_given_cert_name");
+    });
+
+    it("Get a given wildcard certificate name", async () => {
+      AWS.mock("ACM", "listCertificates", certTestData);
+
+      const options = {
+        domainName: '*.test_domain'
+      }
+      const plugin = constructPlugin(options);
+      plugin.acm = new aws.ACM();
+
+      const dc: DomainConfig = new DomainConfig(plugin.serverless.service.custom.customDomain);
+
+      const result = await plugin.getCertArn(dc);
+
+      expect(result).to.equal("test_arn");
     });
 
     it("Create a domain name", async () => {


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #358

**Description of Issue Fixed**
The example in the README.md allows for a wildcard when specifying
a custom domain in the certificateName

```
custom:
  customDomain:
    domainName: serverless.foo.com
    stage: ci
    basePath: api
    certificateName: '*.foo.com'
    createRoute53Record: true
    endpointType: 'regional'
    securityPolicy: tls_1_2
    apiType: rest
```

However, the current implementation throws an error because getCertArn
doesn't strip the wildcard and '.' from the user-specified certificateName.
`certificateArn` is undefined and the `sls create_domain` command fails.

This fix strips '\*.' from certificateName if certificateName starts with
'*'.

'*.foo.com' -> 'foo.com'

I also added a test "Get a given wildcard certificate name".

**Changes proposed in this pull request**:

* Strip '\*.' from `certificateName` if `certificateName` starts with '*' 
* Add test for when `certificateName` starts with '*'

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->
