### PR TITLE
Add an option to disable IPv6 (don't create the AAAA record in Route 53).

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ custom:
     basePath: api
     certificateName: '*.foo.com'
     createRoute53Record: true
+    createRoute53IPv6Record: true
     endpointType: 'regional'
     securityPolicy: tls_1_2
     apiType: rest
@@ -84,6 +85,7 @@ custom:
       basePath: api
       certificateName: '*.foo.com'
       createRoute53Record: true
+      createRoute53IPv6Record: true
       endpointType: 'regional'
       securityPolicy: tls_1_2
     http:
@@ -92,6 +94,7 @@ custom:
       basePath: api
       certificateName: '*.foo.com'
       createRoute53Record: true
+      createRoute53IPv6Record: true
       endpointType: 'regional'
       securityPolicy: tls_1_2
     websocket:
@@ -100,6 +103,7 @@ custom:
       basePath: api
       certificateName: '*.foo.com'
       createRoute53Record: true
+      createRoute53IPv6Record: true
       endpointType: 'regional'
       securityPolicy: tls_1_2
 ```
@@ -111,7 +115,8 @@ custom:
 | stage | Value of `--stage`, or `provider.stage` (serverless will default to `dev` if unset) | The stage to create the domain name for. This parameter allows you to specify a different stage for the domain name than the stage specified for the serverless deployment. |
 | certificateName | Closest match | The name of a specific certificate from Certificate Manager to use with this API. If not specified, the closest match will be used (i.e. for a given domain name `api.example.com`, a certificate for `api.example.com` will take precedence over a `*.example.com` certificate). <br><br> Note: Edge-optimized endpoints require that the certificate be located in `us-east-1` to be used with the CloudFront distribution. |
 | certificateArn | `(none)` | The arn of a specific certificate from Certificate Manager to use with this API. |
-| createRoute53Record | `true` | Toggles whether or not the plugin will create an A Alias and AAAA Alias records in Route53 mapping the `domainName` to the generated distribution domain name. If false, does not create a record. |
+| createRoute53Record | `true` | Toggles whether or not the plugin will create A Alias and AAAA Alias records in Route53 mapping the `domainName` to the generated distribution domain name. If false, does not create a record. |
+| createRoute53IPv6Record | `true` | Toggles whether or not the plugin will create an AAAA Alias record in Route53 mapping the `domainName` to the generated distribution domain name. If false, does not create a record. |
 | endpointType | edge | Defines the endpoint type, accepts `regional` or `edge`. |
 | apiType | rest | Defines the api type, accepts `rest`, `http` or `websocket`. |
 | hostedZoneId | | If hostedZoneId is set the route53 record set will be created in the matching zone, otherwise the hosted zone will be figured out from the domainName (hosted zone with matching domain). |

--- a/src/DomainConfig.ts
+++ b/src/DomainConfig.ts
@@ -14,6 +14,7 @@ class DomainConfig {
     public certificateName: string | undefined;
     public certificateArn: string | undefined;
     public createRoute53Record: boolean | undefined;
+    public createRoute53IPv6Record: boolean | undefined;
     public endpointType: string | undefined;
     public apiType: string | undefined;
     public hostedZoneId: string | undefined;
@@ -34,6 +35,7 @@ class DomainConfig {
         this.certificateArn = config.certificateArn;
         this.certificateName = config.certificateName;
         this.createRoute53Record = config.createRoute53Record;
+        this.createRoute53IPv6Record = config.createRoute53IPv6Record;
         this.hostedZoneId = config.hostedZoneId;
         this.hostedZonePrivate = config.hostedZonePrivate;
         this.allowPathMatching = config.allowPathMatching;

--- a/src/index.ts
+++ b/src/index.ts
@@ -471,9 +471,17 @@ class ServerlessCustomDomain {
             this.serverless.cli.log(`Skipping ${action === "DELETE" ? "removal" : "creation"} of Route53 record.`);
             return;
         }
+
+        const recordsToCreate = ["A"];
+        const createRoute53IPv6Record = domain.createRoute53IPv6Record;
+
+        if (createRoute53IPv6Record !== false) {
+            recordsToCreate.push("AAAA");
+        }
+
         // Set up parameters
         const route53HostedZoneId = await this.getRoute53HostedZoneId(domain);
-        const Changes = ["A", "AAAA"].map((Type) => ({
+        const Changes = recordsToCreate.map((Type) => ({
                 Action: action,
                 ResourceRecordSet: {
                     AliasTarget: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface ServerlessInstance { // tslint:disable-line
                 certificateName: string | undefined,
                 certificateArn: string | undefined,
                 createRoute53Record: boolean | undefined,
+                createRoute53IPv6Record: boolean | undefined,
                 endpointType: string | undefined,
                 apiType: string | undefined,
                 hostedZoneId: string | undefined,


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #364 

Add the ability to create the A record but not the AAAA record in Route 53.

**Changes proposed in this pull request**:

* Add an option `createRoute53IPv6Record` which, if set to false, skips creation of the IPv6 (AAAA) record even if `createRoute53Record` is true.

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->
