### PR TITLE
fix: include all of dist folder in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "*.js",
     "*.ts",
     "*.json",
-    "dist/*.js"
+    "dist"
   ],
   "nyc": {
     "extension": [


### PR DESCRIPTION
**Description of Issue Fixed**
The latest npm package fails with `Error: Cannot find module './aws/cloud-formation-wrapper'`
When looking at the package in the node_modules, the aws folder is not included due to the `dist/*.js` glob in the files array in the package.json

**Changes proposed in this pull request**:

* Include all of dist folder in npm package
