### PR TITLE
Add config option to avoid automatically deleting an APIGW domain when other base path mappings exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ securityPolicy | tls_1_2 | The security policy to apply to the custom domain nam
 allowPathMatching | false | When updating an existing api mapping this will match on the basePath instead of the API ID to find existing mappings for an upsate. This should only be used when changing API types. For example, migrating a REST API to an HTTP API. See Changing API Types for more information.  |
 | autoDomain | `false` | Toggles whether or not the plugin will run `create_domain/delete_domain` as part of `sls deploy/remove` so that multiple commands are not required. |
 | autoDomainWaitFor | `120` | How long to wait for create_domain to finish before starting deployment if domain does not exist immediately. |
+| preserveExternalPathMappings | `false` | When `autoDomain` is set to true, and a deployment is removed, setting this wto `true` checks for additional API Gateway base path mappings before automatically deleting the domain, and avoids doing so if they exist. |
 
 
 

--- a/src/DomainConfig.ts
+++ b/src/DomainConfig.ts
@@ -25,6 +25,7 @@ class DomainConfig {
     public securityPolicy: string | undefined;
     public autoDomain: boolean | undefined;
     public autoDomainWaitFor: string | undefined;
+    public preserveExternalPathMappings: boolean | undefined;
 
     public domainInfo: DomainInfo | undefined;
     public apiId: string | undefined;
@@ -44,6 +45,7 @@ class DomainConfig {
         this.allowPathMatching = config.allowPathMatching;
         this.autoDomain = config.autoDomain;
         this.autoDomainWaitFor = config.autoDomainWaitFor;
+        this.preserveExternalPathMappings = config.preserveExternalPathMappings;
 
         let basePath = config.basePath;
         if (basePath == null || basePath.trim() === "") {

--- a/src/aws/api-gateway-wrapper.ts
+++ b/src/aws/api-gateway-wrapper.ts
@@ -256,8 +256,10 @@ class APIGatewayWrapper {
           "NextToken",
           {DomainName: domain.givenDomainName},
         );
-        return mappings.filter(mapping =>
-          !(mapping.ApiId === domain.apiId || (mapping.ApiMappingKey === domain.basePath && domain.allowPathMatching))
+        return mappings.filter((mapping) =>
+          !(mapping.ApiId === domain.apiId ||
+            (mapping.ApiMappingKey === domain.basePath && domain.allowPathMatching)
+          ),
         ).length > 0;
     }
 }

--- a/src/aws/api-gateway-wrapper.ts
+++ b/src/aws/api-gateway-wrapper.ts
@@ -242,6 +242,24 @@ class APIGatewayWrapper {
             Globals.logInfo(`Unable to remove basepath mapping for ${domain.givenDomainName}`);
         }
     }
+
+    /**
+     * Checks for presence of external basepath mappings
+     */
+    public async checkExternalPathMappings(domain: DomainConfig): Promise<boolean> {
+        Globals.logInfo(`Checking for additional base path mappings on ${domain.givenDomainName}...`);
+        const mappings: Array<any> = await getAWSPagedResults(
+          this.apiGatewayV2,
+          "getApiMappings",
+          "Items",
+          "NextToken",
+          "NextToken",
+          {DomainName: domain.givenDomainName},
+        );
+        return mappings.filter(mapping =>
+          !(mapping.ApiId === domain.apiId || (mapping.ApiMappingKey === domain.basePath && domain.allowPathMatching))
+        ).length > 0;
+    }
 }
 
 export = APIGatewayWrapper;

--- a/src/aws/api-gateway-wrapper.ts
+++ b/src/aws/api-gateway-wrapper.ts
@@ -248,7 +248,7 @@ class APIGatewayWrapper {
      */
     public async checkExternalPathMappings(domain: DomainConfig): Promise<boolean> {
         Globals.logInfo(`Checking for additional base path mappings on ${domain.givenDomainName}...`);
-        const mappings: Array<any> = await getAWSPagedResults(
+        const mappings = await getAWSPagedResults(
           this.apiGatewayV2,
           "getApiMappings",
           "Items",

--- a/src/index.ts
+++ b/src/index.ts
@@ -318,7 +318,9 @@ class ServerlessCustomDomain {
                     domain.apiMapping = await this.apiGatewayWrapper.getBasePathMapping(domain);
                     await this.apiGatewayWrapper.deleteBasePathMapping(domain);
                     if (preserveExternalPathMappings) {
-                        noExternalPathMappingsOnDomain = (await this.apiGatewayWrapper.checkExternalPathMappings(domain) === false);
+                        noExternalPathMappingsOnDomain = (
+                          await this.apiGatewayWrapper.checkExternalPathMappings(domain) === false
+                        );
                     }
                 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface CustomDomain { // tslint:disable-line
     autoDomain: boolean | undefined;
     autoDomainWaitFor: string | undefined;
     allowPathMatching: boolean | undefined;
+    preserveExternalPathMappings: boolean | undefined;
 }
 
 export interface ServerlessInstance { // tslint:disable-line

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -1858,9 +1858,9 @@ describe("Custom Domain Plugin", () => {
                         {ApiId: "test_rest_api_id", MappingKey: "test", ApiMappingId: "test_mapping_id", Stage: "test"},
                         {
                             ApiId: "test_rest_api_id_2",
-                            MappingKey: "test",
                             ApiMappingId: "test_mapping_id",
-                            Stage: "test"
+                            MappingKey: "test",
+                            Stage: "test",
                         },
                     ],
                 });

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -53,9 +53,9 @@ const constructPlugin = (customDomainOptions, multiple: boolean = false) => {
         endpointType: customDomainOptions.endpointType,
         hostedZoneId: customDomainOptions.hostedZoneId,
         hostedZonePrivate: customDomainOptions.hostedZonePrivate,
+        preserveExternalPathMappings: customDomainOptions.preserveExternalPathMappings,
         securityPolicy: customDomainOptions.securityPolicy,
         stage: customDomainOptions.stage,
-		    preserveExternalPathMappings: customDomainOptions.preserveExternalPathMappings,
     };
 
     const serverless = {
@@ -1841,7 +1841,8 @@ describe("Custom Domain Plugin", () => {
             expect(spy).to.have.not.been.called();
         });
 
-        it("removeBasePathMapping should not call deleteDomain when preserveExternalPathMappings is true and external mappings exist", async () => {
+        it("removeBasePathMapping should not call deleteDomain when preserveExternalPathMappings is true and " +
+          "external mappings exist", async () => {
             AWS.mock("CloudFormation", "describeStackResource", (params, callback) => {
                 callback(null, {
                     StackResourceDetail:
@@ -1855,7 +1856,12 @@ describe("Custom Domain Plugin", () => {
                 callback(null, {
                     Items: [
                         {ApiId: "test_rest_api_id", MappingKey: "test", ApiMappingId: "test_mapping_id", Stage: "test"},
-                        {ApiId: "test_rest_api_id_2", MappingKey: "test", ApiMappingId: "test_mapping_id", Stage: "test"},
+                        {
+                            ApiId: "test_rest_api_id_2",
+                            MappingKey: "test",
+                            ApiMappingId: "test_mapping_id",
+                            Stage: "test"
+                        },
                     ],
                 });
             });
@@ -1870,11 +1876,11 @@ describe("Custom Domain Plugin", () => {
             });
 
             const plugin = constructPlugin({
-                preserveExternalPathMappings: true,
                 autoDomain: true,
                 basePath: "test_basepath",
                 createRoute53Record: false,
                 domainName: "test_domain",
+                preserveExternalPathMappings: true,
                 restApiId: "test_rest_api_id",
             });
             plugin.initializeVariables();
@@ -1891,7 +1897,8 @@ describe("Custom Domain Plugin", () => {
             expect(spy).to.have.not.been.called();
         });
 
-        it("removeBasePathMapping should call deleteDomain when preserveExternalPathMappings is true and external mappings don't exist", async () => {
+        it("removeBasePathMapping should call deleteDomain when preserveExternalPathMappings is true and " +
+          "external mappings don't exist", async () => {
             AWS.mock("CloudFormation", "describeStackResource", (params, callback) => {
                 callback(null, {
                     StackResourceDetail:
@@ -1919,11 +1926,11 @@ describe("Custom Domain Plugin", () => {
             });
 
             const plugin = constructPlugin({
-                preserveExternalPathMappings: true,
                 autoDomain: true,
                 basePath: "test_basepath",
                 createRoute53Record: false,
                 domainName: "test_domain",
+                preserveExternalPathMappings: true,
                 restApiId: "test_rest_api_id",
             });
             plugin.initializeVariables();


### PR DESCRIPTION
Feature request: Add config option to avoid automatically deleting an APIGW domain when other base path mappings exist

When `autoDomain` is set to `true` in this plugin, running `sls remove` on a deployed service will remove the APIGW custom domain regardless of whether base path mappings exist other than the one the plugin defines for this service. 

This change introduces a `preserveExternalPathMappings` config option to check for other path mappings - either defined through this plugin in other services, or otherwise externally - before removing the custom domain.

When this is enabled, in a scenario where n>1 deployed services use this plugin, and are set to the same `customDomain.domainName`, the n...n-1 services to be removed should NOT remove the custom domain, whereas the nth will.
