### PR TITLE
Add custom route53 profile options

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ custom:
 | certificateName | Closest match | The name of a specific certificate from Certificate Manager to use with this API. If not specified, the closest match will be used (i.e. for a given domain name `api.example.com`, a certificate for `api.example.com` will take precedence over a `*.example.com` certificate). <br><br> Note: Edge-optimized endpoints require that the certificate be located in `us-east-1` to be used with the CloudFront distribution. |
 | certificateArn | `(none)` | The arn of a specific certificate from Certificate Manager to use with this API. |
 | createRoute53Record | `true` | Toggles whether or not the plugin will create an A Alias and AAAA Alias records in Route53 mapping the `domainName` to the generated distribution domain name. If false, does not create a record. |
+| route53Profile | `(none)` | Profile to use for accessing Route53 resources |
+| route53Region | `(none)` | Region to send Route53 services requests to (only applicable if also using route53Profile option) |
 | endpointType | edge | Defines the endpoint type, accepts `regional` or `edge`. |
 | apiType | rest | Defines the api type, accepts `rest`, `http` or `websocket`. |
 | hostedZoneId | | If hostedZoneId is set the route53 record set will be created in the matching zone, otherwise the hosted zone will be figured out from the domainName (hosted zone with matching domain). |

--- a/src/DomainConfig.ts
+++ b/src/DomainConfig.ts
@@ -17,6 +17,8 @@ class DomainConfig {
     public certificateName: string | undefined;
     public certificateArn: string | undefined;
     public createRoute53Record: boolean | undefined;
+    public route53Profile: string | undefined;
+    public route53Region: string | undefined;
     public endpointType: string | undefined;
     public apiType: string | undefined;
     public hostedZoneId: string | undefined;
@@ -39,6 +41,8 @@ class DomainConfig {
         this.certificateArn = config.certificateArn;
         this.certificateName = config.certificateName;
         this.createRoute53Record = config.createRoute53Record;
+        this.route53Profile = config.route53Profile;
+        this.route53Region = config.route53Region;
         this.hostedZoneId = config.hostedZoneId;
         this.hostedZonePrivate = config.hostedZonePrivate;
         this.allowPathMatching = config.allowPathMatching;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ class ServerlessCustomDomain {
 
     // AWS SDK resources
     public apiGatewayWrapper: APIGatewayWrapper;
-    public route53: any;
     public acm: any;
     public cloudFormationWrapper: CloudFormationWrapper;
 
@@ -164,8 +163,33 @@ class ServerlessCustomDomain {
         credentials.region = this.serverless.providers.aws.getRegion();
 
         this.apiGatewayWrapper = new APIGatewayWrapper(credentials);
-        this.route53 = new this.serverless.providers.aws.sdk.Route53(credentials);
         this.cloudFormationWrapper = new CloudFormationWrapper(credentials);
+    }
+
+    /**
+     * Setup route53 resource
+     */
+    public createRoute53Resource(domain: DomainConfig): any {
+      let route53: any;
+
+      const domainProfile = domain.route53Profile;
+      if (domainProfile) {
+        const route53Credentials = new this.serverless.providers.aws.sdk.SharedIniFileCredentials({
+          profile: domainProfile,
+        });
+        const route53Region = domain.route53Region || this.serverless.providers.aws.getRegion();
+
+        route53 = new this.serverless.providers.aws.sdk.Route53({
+          credentials: route53Credentials,
+          region: route53Region,
+        });
+      } else {
+        const credentials = this.serverless.providers.aws.getCredentials();
+        credentials.region = this.serverless.providers.aws.getRegion();
+        route53 = new this.serverless.providers.aws.sdk.Route53(credentials);
+      }
+
+      return route53;
     }
 
     /**
@@ -451,7 +475,7 @@ class ServerlessCustomDomain {
         };
         // Make API call
         try {
-            await throttledCall(this.route53, "changeResourceRecordSets", params);
+            await throttledCall(this.createRoute53Resource(domain), "changeResourceRecordSets", params);
         } catch (err) {
             Globals.logError(err, domain.givenDomainName);
             throw new Error(`Failed to ${action} A Alias for ${domain.givenDomainName}\n`);
@@ -478,7 +502,7 @@ class ServerlessCustomDomain {
         const givenDomainNameReverse = domain.givenDomainName.split(".").reverse();
 
         try {
-            hostedZoneData = await throttledCall(this.route53, "listHostedZones", {});
+            hostedZoneData = await throttledCall(this.createRoute53Resource(domain), "listHostedZones", {});
             const targetHostedZone = hostedZoneData.HostedZones
                 .filter((hostedZone) => {
                     let hostedZoneName;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@ export interface CustomDomain { // tslint:disable-line
     certificateName: string | undefined;
     certificateArn: string | undefined;
     createRoute53Record: boolean | undefined;
+    route53Profile: string | undefined;
+    route53Region: string | undefined;
     endpointType: string | undefined;
     apiType: string | undefined;
     hostedZoneId: string | undefined;
@@ -46,6 +48,7 @@ export interface ServerlessInstance { // tslint:disable-line
                 config: {
                     update(toUpdate: object): void,
                 },
+                SharedIniFileCredentials: any,
             }
             getCredentials(),
             getRegion(),

--- a/test/integration-tests/basic.test.ts
+++ b/test/integration-tests/basic.test.ts
@@ -112,6 +112,21 @@ describe("Integration Tests", function() {
         }
     });
 
+    it("Can use a specified profile for route53", async () => {
+        const testName = "route53-profile";
+        const configFolder = `${CONFIGS_FOLDER}/${testName}`;
+        const testURL = `${testName}-${RANDOM_STRING}.${TEST_DOMAIN}`;
+        try {
+            await utilities.createTempDir(TEMP_DIR, configFolder);
+            await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
+            await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
+            await utilities.slsCreateDomain(TEMP_DIR, RANDOM_STRING);
+            await utilities.slsDeploy(TEMP_DIR, RANDOM_STRING);
+        } finally {
+            await utilities.destroyResources(testURL, RANDOM_STRING);
+        }
+    });
+
     it("Deploys multiple times without failure", async () => {
         const testName = "deploy-idempotent";
         const configFolder = `${CONFIGS_FOLDER}/${testName}`;

--- a/test/integration-tests/basic/route53-profile/handler.js
+++ b/test/integration-tests/basic/route53-profile/handler.js
@@ -1,0 +1,16 @@
+"use strict";
+
+module.exports.helloWorld = (event, context, callback) => {
+  const response = {
+    statusCode: 200,
+    headers: {
+      "Access-Control-Allow-Origin": "*", // Required for CORS support to work
+    },
+    body: JSON.stringify({
+      message: "Go Serverless v1.0! Your function executed successfully!",
+      input: event,
+    }),
+  };
+
+  callback(null, response);
+};

--- a/test/integration-tests/basic/route53-profile/serverless.yml
+++ b/test/integration-tests/basic/route53-profile/serverless.yml
@@ -1,0 +1,26 @@
+# Creating a domain should be idempotent
+service: route53-profile-${opt:RANDOM_STRING}
+provider:
+  name: aws
+  runtime: nodejs12.x
+  region: us-west-2
+  stage: test
+functions:
+  helloWorld:
+    handler: handler.helloWorld
+    events:
+      - http:
+          path: hello-world
+          method: get
+          cors: true
+plugins:
+  - serverless-domain-manager
+
+custom:
+  customDomain:
+    domainName: route53-profile-${opt:RANDOM_STRING}.${env:TEST_DOMAIN}
+    route53Profile: default
+
+package:
+  exclude:
+    - node_modules/**

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -53,6 +53,8 @@ const constructPlugin = (customDomainOptions, multiple: boolean = false) => {
         endpointType: customDomainOptions.endpointType,
         hostedZoneId: customDomainOptions.hostedZoneId,
         hostedZonePrivate: customDomainOptions.hostedZonePrivate,
+        route53Profile: customDomainOptions.route53Profile,
+        route53Region: customDomainOptions.route53Region,
         securityPolicy: customDomainOptions.securityPolicy,
         stage: customDomainOptions.stage,
     };
@@ -76,6 +78,7 @@ const constructPlugin = (customDomainOptions, multiple: boolean = false) => {
                     ApiGatewayV2: aws.ApiGatewayV2,
                     CloudFormation: aws.CloudFormation,
                     Route53: aws.Route53,
+                    SharedIniFileCredentials: aws.SharedIniFileCredentials,
                     config: {
                         update: (toUpdate: object) => null,
                     },
@@ -120,6 +123,23 @@ describe("Custom Domain Plugin", () => {
         const returnedCreds = plugin.apiGatewayWrapper.apiGateway.config.credentials;
         expect(returnedCreds.accessKeyId).to.equal(testCreds.accessKeyId);
         expect(returnedCreds.sessionToken).to.equal(testCreds.sessionToken);
+    });
+
+    describe("custom route53 profile", () => {
+      it("uses the provided profile for route53", () => {
+        const route53ProfileConfig = {
+          route53Profile: "testroute53profile",
+          route53Region: "area-53-zone",
+        };
+        const plugin = constructPlugin(route53ProfileConfig);
+
+        plugin.initAWSResources();
+        const dc: DomainConfig = new DomainConfig(plugin.serverless.service.custom.customDomain);
+        const route53 = plugin.createRoute53Resource(dc);
+
+        expect(route53.config.credentials.profile).to.equal(route53ProfileConfig.route53Profile);
+        expect(route53.config.region).to.equal(route53ProfileConfig.route53Region);
+      });
     });
 
     describe("Domain Endpoint types", () => {
@@ -633,7 +653,8 @@ describe("Custom Domain Plugin", () => {
             });
 
             const plugin = constructPlugin({basePath: "test_basepath", domainName: "test_domain"});
-            plugin.route53 = new aws.Route53();
+            const route53 = new aws.Route53();
+            plugin.createRoute53Resource = () => route53;
 
             const dc: DomainConfig = new DomainConfig(plugin.serverless.service.custom.customDomain);
 
@@ -644,7 +665,7 @@ describe("Custom Domain Plugin", () => {
                 },
             );
 
-            const spy = chai.spy.on(plugin.route53, "changeResourceRecordSets");
+            const spy = chai.spy.on(route53, "changeResourceRecordSets");
 
             await plugin.changeResourceRecordSet("UPSERT", dc);
 
@@ -965,11 +986,12 @@ describe("Custom Domain Plugin", () => {
                 basePath: "test_basepath",
                 domainName: "test_domain",
             });
-            plugin.route53 = new aws.Route53();
+            const route53 = new aws.Route53();
+            plugin.createRoute53Resource = () => route53;
 
             const dc: DomainConfig = new DomainConfig(plugin.serverless.service.custom.customDomain);
 
-            const spy = chai.spy.on(plugin.route53, "changeResourceRecordSets");
+            const spy = chai.spy.on(route53, "changeResourceRecordSets");
 
             dc.domainInfo = new DomainInfo({
                 distributionDomainName: "test_distribution_name",
@@ -1106,7 +1128,7 @@ describe("Custom Domain Plugin", () => {
             const plugin = constructPlugin({domainName: "test_domain"});
             plugin.initializeVariables();
             plugin.initAWSResources();
-            plugin.route53 = new aws.Route53();
+            plugin.createRoute53Resource = () => new aws.Route53();
 
             await plugin.deleteDomains();
             expect(consoleOutput[0]).to.equal(`Custom domain ${plugin.domains[0].givenDomainName} was deleted.`);
@@ -1131,7 +1153,7 @@ describe("Custom Domain Plugin", () => {
 
             const plugin = constructPlugin({domainName: "test_domain"});
             plugin.initializeVariables();
-            plugin.route53 = new aws.Route53();
+            plugin.createRoute53Resource = () => new aws.Route53();
             plugin.domains.forEach((d) => {
                 d.acm = new aws.ACM();
             });
@@ -1162,7 +1184,7 @@ describe("Custom Domain Plugin", () => {
             const plugin = constructPlugin({domainName: "test_domain"});
             plugin.initializeVariables();
             plugin.initAWSResources();
-            plugin.route53 = new aws.Route53();
+            plugin.createRoute53Resource = () => new aws.Route53();
             plugin.initializeVariables();
             plugin.domains.forEach((d) => {
                 d.acm = new aws.ACM();
@@ -1191,7 +1213,7 @@ describe("Custom Domain Plugin", () => {
             });
 
             const plugin = constructPlugin({domainName: "ccc.bbb.aaa.com"});
-            plugin.route53 = new aws.Route53();
+            plugin.createRoute53Resource = () => new aws.Route53();
             plugin.initializeVariables();
             const result = await plugin.getRoute53HostedZoneId(plugin.domains[0]);
             expect(result).to.equal("test_id_2");
@@ -1210,7 +1232,7 @@ describe("Custom Domain Plugin", () => {
             });
 
             const plugin = constructPlugin({domainName: "test.ccc.bbb.aaa.com"});
-            plugin.route53 = new aws.Route53();
+            plugin.createRoute53Resource = () => new aws.Route53();
             plugin.initializeVariables();
 
             const result = await plugin.getRoute53HostedZoneId(plugin.domains[0]);
@@ -1230,7 +1252,7 @@ describe("Custom Domain Plugin", () => {
             });
 
             const plugin = constructPlugin({domainName: "test.ccc.bbb.aaa.com"});
-            plugin.route53 = new aws.Route53();
+            plugin.createRoute53Resource = () => new aws.Route53();
             plugin.initializeVariables();
 
             const result = await plugin.getRoute53HostedZoneId(plugin.domains[0]);
@@ -1249,7 +1271,7 @@ describe("Custom Domain Plugin", () => {
             });
 
             const plugin = constructPlugin({domainName: "bar.foo.bbb.fr"});
-            plugin.route53 = new aws.Route53();
+            plugin.createRoute53Resource = () => new aws.Route53();
             plugin.initializeVariables();
 
             const result = await plugin.getRoute53HostedZoneId(plugin.domains[0]);
@@ -1267,7 +1289,7 @@ describe("Custom Domain Plugin", () => {
             });
 
             const plugin = constructPlugin({domainName: "test.a.aaa.com"});
-            plugin.route53 = new aws.Route53();
+            plugin.createRoute53Resource = () => new aws.Route53();
             plugin.initializeVariables();
 
             const result = await plugin.getRoute53HostedZoneId(plugin.domains[0]);
@@ -1287,7 +1309,7 @@ describe("Custom Domain Plugin", () => {
             });
 
             const plugin = constructPlugin({domainName: "bar.foo.bbb.fr"});
-            plugin.route53 = new aws.Route53();
+            plugin.createRoute53Resource = () => new aws.Route53();
             plugin.initializeVariables();
 
             const result = await plugin.getRoute53HostedZoneId(plugin.domains[0]);
@@ -1307,7 +1329,7 @@ describe("Custom Domain Plugin", () => {
             });
 
             const plugin = constructPlugin({domainName: "bar.foo.bbb.fr"});
-            plugin.route53 = new aws.Route53();
+            plugin.createRoute53Resource = () => new aws.Route53();
             plugin.initializeVariables();
 
             const result = await plugin.getRoute53HostedZoneId(plugin.domains[0]);
@@ -1326,7 +1348,7 @@ describe("Custom Domain Plugin", () => {
             });
 
             const plugin = constructPlugin({domainName: "bar.foo.bbb.fr"});
-            plugin.route53 = new aws.Route53();
+            plugin.createRoute53Resource = () => new aws.Route53();
             plugin.initializeVariables();
 
             const result = await plugin.getRoute53HostedZoneId(plugin.domains[0]);
@@ -1343,7 +1365,7 @@ describe("Custom Domain Plugin", () => {
             });
 
             const plugin = constructPlugin({domainName: "aaa.com", hostedZonePrivate: true});
-            plugin.route53 = new aws.Route53();
+            plugin.createRoute53Resource = () => new aws.Route53();
             plugin.initializeVariables();
 
             const result = await plugin.getRoute53HostedZoneId(plugin.domains[0]);
@@ -1360,7 +1382,7 @@ describe("Custom Domain Plugin", () => {
             });
 
             const plugin = constructPlugin({domainName: "aaa.com"});
-            plugin.route53 = new aws.Route53();
+            plugin.createRoute53Resource = () => new aws.Route53();
             plugin.initializeVariables();
 
             const result = await plugin.getRoute53HostedZoneId(plugin.domains[0]);
@@ -1402,7 +1424,7 @@ describe("Custom Domain Plugin", () => {
 
             const plugin = constructPlugin({domainName: "test_domain"});
             plugin.initializeVariables();
-            plugin.route53 = new aws.Route53();
+            plugin.createRoute53Resource = () => new aws.Route53();
             plugin.initializeVariables();
 
             return plugin.getRoute53HostedZoneId(plugin.domains[0]).then(() => {


### PR DESCRIPTION
**Description of Issue Fixed**

Allows specifying a different AWS profile for route53 resources from the profile used by serverless. For cases where route53 is managed by an account different from the account in which the current service is being deployed.

Renewed attempt to get this functionality included, basically #198 adapted to the current version.

**Changes proposed in this pull request**:

* Add route53Profile and route53Region parameters 

Let me know what you think / what's needed to get this incorporated. Thanks!