### PR TITLE
Improve handling of boolean config createRoute53Record

### DIFF
--- a/src/DomainConfig.ts
+++ b/src/DomainConfig.ts
@@ -103,8 +103,7 @@ class DomainConfig {
         }
         if (typeof booleanConfig === "boolean") {
             return booleanConfig;
-        }
-        else if (typeof booleanConfig === "string" && booleanConfig === "true") {
+        } else if (typeof booleanConfig === "string" && booleanConfig === "true") {
             return true;
         } else if (typeof booleanConfig === "string" && booleanConfig === "false") {
             return false;

--- a/src/DomainConfig.ts
+++ b/src/DomainConfig.ts
@@ -33,12 +33,12 @@ class DomainConfig {
 
     constructor(config: CustomDomain) {
 
-        this.enabled = this.evaluateEnabled(config.enabled);
+        this.enabled = this.evaluateBoolean(config.enabled, true);
         this.givenDomainName = config.domainName;
         this.hostedZonePrivate = config.hostedZonePrivate;
         this.certificateArn = config.certificateArn;
         this.certificateName = config.certificateName;
-        this.createRoute53Record = config.createRoute53Record;
+        this.createRoute53Record = this.evaluateBoolean(config.createRoute53Record, true);
         this.hostedZoneId = config.hostedZoneId;
         this.hostedZonePrivate = config.hostedZonePrivate;
         this.allowPathMatching = config.allowPathMatching;
@@ -87,27 +87,29 @@ class DomainConfig {
     }
 
     /**
-     * Determines whether this plug-in is enabled.
+     * Determines whether this boolean config is configured to true or false.
      *
-     * This method reads the customDomain property "enabled" to see if this plug-in should be enabled.
-     * If the property's value is undefined, a default value of true is assumed (for backwards
-     * compatibility).
-     * If the property's value is provided, this should be boolean, otherwise an exception is thrown.
-     * If no customDomain object exists, an exception is thrown.
+     * This method evaluates a customDomain property to see if it's true or false.
+     * If the property's value is undefined, the default value is returned.
+     * If the property's value is provided, this should be boolean, or a string parseable as boolean,
+     * otherwise an exception is thrown.
+     * @param {boolean|string} booleanConfig the config value provided
+     * @param {boolean} defaultValue the default value to return, if config value is undefined
+     * @returns {boolean} the parsed boolean from the config value, or the default value
      */
-    private evaluateEnabled(enabled: any): boolean {
-        // const enabled = this.serverless.service.custom.customDomain.enabled;
-        if (enabled === undefined) {
-            return true;
+    private evaluateBoolean(booleanConfig: any, defaultValue: boolean): boolean {
+        if (booleanConfig === undefined) {
+            return defaultValue;
         }
-        if (typeof enabled === "boolean") {
-            return enabled;
-        } else if (typeof enabled === "string" && enabled === "true") {
+        if (typeof booleanConfig === "boolean") {
+            return booleanConfig;
+        }
+        else if (typeof booleanConfig === "string" && booleanConfig === "true") {
             return true;
-        } else if (typeof enabled === "string" && enabled === "false") {
+        } else if (typeof booleanConfig === "string" && booleanConfig === "false") {
             return false;
         }
-        throw new Error(`${Globals.pluginName}: Ambiguous enablement boolean: "${enabled}"`);
+        throw new Error(`${Globals.pluginName}: Ambiguous boolean config: "${booleanConfig}"`);
     }
 }
 

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -1585,7 +1585,7 @@ describe("Custom Domain Plugin", () => {
                 await plugin.hookWrapper(null);
             } catch (err) {
                 errored = true;
-                expect(err.message).to.equal(`${Globals.pluginName}: Ambiguous enablement boolean: \"0\"`);
+                expect(err.message).to.equal(`${Globals.pluginName}: Ambiguous boolean config: \"0\"`);
             }
             expect(errored).to.equal(true);
         });
@@ -1598,7 +1598,7 @@ describe("Custom Domain Plugin", () => {
                 await plugin.hookWrapper(null);
             } catch (err) {
                 errored = true;
-                expect(err.message).to.equal(`${Globals.pluginName}: Ambiguous enablement boolean: \"yes\"`);
+                expect(err.message).to.equal(`${Globals.pluginName}: Ambiguous boolean config: \"yes\"`);
             }
             expect(errored).to.equal(true);
         });


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #402 

**Description of Issue Fixed**
The issue with the createRoute53Record was that it needs to be provided as boolean type and doesn't work as expected if coming in as a string type. 
So
`createRoute53Record: false`
does not work but
`createRoute53Record: ${strToBool(false)}` 
does work.

The `enabled` property can handle the property value coming in as a string in a good way.

**Changes proposed in this pull request**:
* Using the same method for parsing createRoute53Record config value as for the `enabled` property.

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->
