### PR TITLE
Register `serverless` as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
   "dependencies": {
     "aws-sdk": "^2.756.0",
     "chalk": "^4.1.0"
+  },
+  "peerDependencies": {
+    "serverless": "1 || 2"
   }
 }


### PR DESCRIPTION
It's to ensure only compatible versions or Framework are used together with a plugin, and if mismatch occurs, user is informed with meaningful error message.

_This PR is part of Serverless Framework initiative to [curate most popular plugins](https://github.com/serverless/serverless/issues/9025)_

