### PR TITLE
Adds error logging for getDomainName API fail

### DIFF
--- a/src/aws/api-gateway-wrapper.ts
+++ b/src/aws/api-gateway-wrapper.ts
@@ -91,7 +91,7 @@ class APIGatewayWrapper {
     }
 
     /**
-     * Delete Custom Domain Name through API Gateway
+     * Get Custom Domain Info through API Gateway
      */
     public async getCustomDomainInfo(domain: DomainConfig): Promise<DomainInfo> {
         // Make API call
@@ -102,6 +102,7 @@ class APIGatewayWrapper {
             return new DomainInfo(domainInfo);
         } catch (err) {
             if (err.code !== "NotFoundException") {
+                Globals.logError(err, domain.givenDomainName);
                 throw new Error(`Unable to fetch information about ${domain.givenDomainName}`);
             }
             Globals.logError(`${domain.givenDomainName} does not exist`);


### PR DESCRIPTION
**Description of Issue Fixed**
If `getCustomDomainInfo` throws an error who's code is not "NotFoundException", there is no information written to the log. This prevents the user from knowing the cause of the failure.

**Changes proposed in this pull request**:
Add logging of the error to the console

* Update the comment describing the function
* Add a log statement with the error and domain name

