### PR TITLE
Export Domain & Distribution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -589,15 +589,24 @@ class ServerlessCustomDomain {
 
         service.provider.compiledCloudFormationTemplate.Outputs[distributionDomainNameOutputKey] = {
             Value: domain.domainInfo.domainName,
+            Export: {
+                Name: `sls-${service.service}-${domain.stage}-${distributionDomainNameOutputKey}`,
+            },
         };
 
         service.provider.compiledCloudFormationTemplate.Outputs[domainNameOutputKey] = {
             Value: domain.givenDomainName,
+            Export: {
+                Name: `sls-${service.service}-${domain.stage}-${domainNameOutputKey}`,
+            },
         };
 
         if (domain.domainInfo.hostedZoneId) {
             service.provider.compiledCloudFormationTemplate.Outputs[hostedZoneIdOutputKey] = {
                 Value: domain.domainInfo.hostedZoneId,
+                Export: {
+                    Name: `sls-${service.service}-${domain.stage}-${hostedZoneIdOutputKey}`,
+                },
             };
         }
     }


### PR DESCRIPTION
As per [addExportNameForOutputs.js](https://github.com/serverless/serverless/blob/master/lib/plugins/aws/package/lib/addExportNameForOutputs.js) it's useful to export the Domain & Distribution so that they can be referenced from other stacks:

```
Resources:
  dnsAliasRecord:
    Type: AWS::Route53::RecordSet
    Properties:
      Name: !ImportValue
        'Fn::Sub': 'sls-${Service}-${Stage}-DomainName'
      Type: A
      HostedZoneId: !Ref HostedZoneId
      AliasTarget:
        DNSName: !ImportValue
          'Fn::Sub': 'sls-${Service}-${Stage}-DistributionDomainName'
        HostedZoneId: Z2FDTNDATAQYW2
```
