### PR TITLE
Mark plugin as Serverless Framework v3 compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     "chalk": "^4.1.2"
   },
   "peerDependencies": {
-    "serverless": "1 || 2"
+    "serverless": "1 || 2 || 3"
   }
 }


### PR DESCRIPTION
Plugin as is, will work with Serverless Framework v3 without issues, therefore it'll be great to mark it as compliant (so it doesn't report a lack of compatibility once v3 is released)

For complete adaptation, it'll be great if it also comes with modern logs (addressed at #448)