### PR TITLE
AT-5523: update peerDependencies due to official version marker 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [5.3.0] - 2021-12-17
+## [5.3.0] - 2021-12-20
 - Added support of Serverless version 3. Thank you @medikoo ([449](https://github.com/amplify-education/serverless-domain-manager/pull/449))
 - Integration test refactoring
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
     "aws-sdk": "^2.1046.0"
   },
   "peerDependencies": {
-    "serverless": "1 || 2 || 3"
+    "serverless": "<4"
   }
 }


### PR DESCRIPTION
Trying to fix npm publish 
Here are the official version patterns https://docs.npmjs.com/cli/v7/configuring-npm/package-json#dependencies