### PR TITLE
Fix for gh-450: check AWS certificate expiry date before trying to use it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log
 **/.serverless
 dist/
 .nyc_output/
+*.tgz

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "integration-basic": "nyc mocha -r ts-node/register --project tsconfig.json --parallel test/integration-tests/basic.test.ts",
     "integration-deploy": "nyc mocha -r ts-node/register --project tsconfig.json --parallel test/integration-tests/deploy.test.ts",
     "test": "nyc mocha -r ts-node/register --project tsconfig.json test/unit-tests/index.test.ts && nyc report --reporter=text-summary",
+    "test:debug": "NODE_OPTIONS='--inspect-brk' mocha -j 1 -r ts-node/register --project tsconfig.json test/unit-tests/index.test.ts",
     "integration-test": "npm run integration-basic && npm run integration-deploy && nyc report --reporter=text-summary",
     "lint": "tslint --project . && tslint --project tsconfig.json",
     "build": "tsc --project ."

--- a/src/aws/acm-wrapper.ts
+++ b/src/aws/acm-wrapper.ts
@@ -57,7 +57,7 @@ class ACMWrapper {
                   const currNotAfter = details.Certificate.NotAfter;
                   if (Date.now() < currNotAfter) {
                     Globals.logInfo(`Selecting cert with ARN=${
-                      currArn} with future expiry (${currNotAfter})`);
+                      currArn} with future expiry (${currNotAfter.toISOString()})`);
                     certificateArn = currArn;
                     break;
                   }

--- a/src/aws/acm-wrapper.ts
+++ b/src/aws/acm-wrapper.ts
@@ -62,7 +62,7 @@ class ACMWrapper {
                     break;
                   }
                   Globals.logInfo(`Ignoring cert with ARN=${
-                    currArn} that is expired (${currNotAfter})`);
+                    currArn} that is expired (${currNotAfter.toISOString()})`);
                 }
             } else {
                 certificateName = domain.givenDomainName;


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #450 

**Description of Issue Fixed**
Previously the code didn't allow for
* multiple certificates with the same name
* expired certs

**Changes proposed in this pull request**:

Enumerate all certificates that match the specified name and find the first on that is in-date.

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->
