### PR TITLE
chore: export types for easy reuse

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "target": "es6",
     "sourceMap": false,
     "outDir": "dist",
+    "declaration": true,
     "types": [
       "mocha",
       "node"


### PR DESCRIPTION
**Description of Issue Fixed**

Exports TypeScript types for easy re-use in other plugins.

**Changes proposed in this pull request**:

* Enabling type generation