### PR TITLE
add acm describecertificate permission to README and example cfn

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Make sure you have the following installed before starting:
 The IAM role that is deploying the lambda will need the following permissions:
 ```
 acm:ListCertificates                *
+acm:DescribeCertificate             *
 apigateway:GET                      /domainnames/*
 apigateway:GET                      /domainnames/*/basepathmappings
 apigateway:DELETE                   /domainnames/*

--- a/scripts/cloudformation/serverless-domain-manager-deploy-policy.yaml
+++ b/scripts/cloudformation/serverless-domain-manager-deploy-policy.yaml
@@ -47,6 +47,7 @@ Resources:
           - Effect: Allow
             Action:
               - acm:ListCertificates
+              - acm:DescribeCertificate
             Resource: '*'
           - Effect: Allow
             Action:


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #501 

**Description of Issue Fixed**
Experience failures when trying to run `serverless create_domain` after adding permissions per README or deploying the permissions template. This is due to the lack of the `acm:DescribeCertificate` action. 

**Changes proposed in this pull request**:

* Add `acm:DescribeCertificate` action to README and deployment of permissions template. 

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->
