### PR TITLE
Use uppercase consistently for endpoint type

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ custom:
     certificateName: '*.foo.com'
     createRoute53Record: true
     createRoute53IPv6Record: true
-    endpointType: 'regional'
+    endpointType: REGIONAL
     securityPolicy: tls_1_2
     apiType: rest
     autoDomain: false
@@ -87,7 +87,7 @@ custom:
       certificateName: '*.foo.com'
       createRoute53Record: true
       createRoute53IPv6Record: true
-      endpointType: 'regional'
+      endpointType: REGIONAL
       securityPolicy: tls_1_2
     http:
       domainName: http.serverless.foo.com
@@ -96,7 +96,7 @@ custom:
       certificateName: '*.foo.com'
       createRoute53Record: true
       createRoute53IPv6Record: true
-      endpointType: 'regional'
+      endpointType: REGIONAL
       securityPolicy: tls_1_2
     websocket:
       domainName: ws.serverless.foo.com
@@ -105,7 +105,7 @@ custom:
       certificateName: '*.foo.com'
       createRoute53Record: true
       createRoute53IPv6Record: true
-      endpointType: 'regional'
+      endpointType: REGIONAL
       securityPolicy: tls_1_2
 ```
 
@@ -117,11 +117,11 @@ custom:
     - http:
         domainName: http-api-${opt:RANDOM_STRING}.${env:TEST_DOMAIN}
         basePath: ''
-        endpointType: 'regional'
+        endpointType: REGIONAL
     - http:
         domainName: http-api-${opt:RANDOM_STRING}.${env:TEST_DOMAIN}.foo
         basePath: ''
-        endpointType: 'regional'
+        endpointType: REGIONAL
 ```
 
 For multi-region deployments, a `route53Params` structure can be used to support latency or weighted routing policies
@@ -134,7 +134,7 @@ custom:
     basePath: api
     certificateName: '*.foo.com'
     createRoute53Record: true
-    endpointType: 'regional'
+    endpointType: REGIONAL
     securityPolicy: tls_1_2
     route53Params:
       routingPolicy: latency
@@ -151,7 +151,7 @@ custom:
 | createRoute53IPv6Record | `true` | Toggles whether or not the plugin will create an AAAA Alias record in Route53 mapping the `domainName` to the generated distribution domain name. If false, does not create a record. |
 | route53Profile | `(none)` | Profile to use for accessing Route53 resources when Route53 records are in a different account |
 | route53Region | `(none)` | Region to send Route53 services requests to (only applicable if also using route53Profile option) |
-| endpointType | edge | Defines the endpoint type, accepts `regional` or `edge`. |
+| endpointType | `EDGE` | Defines the endpoint type, accepts `REGIONAL` or `EDGE`. |
 | apiType | rest | Defines the api type, accepts `rest`, `http` or `websocket`. |
 | hostedZoneId | | If hostedZoneId is set the route53 record set will be created in the matching zone, otherwise the hosted zone will be figured out from the domainName (hosted zone with matching domain). |
 | hostedZonePrivate | | If hostedZonePrivate is set to `true` then only private hosted zones will be used for route 53 records. If it is set to `false` then only public hosted zones will be used for route53 records. Setting this parameter is specially useful if you have multiple hosted zones with the same domain name (e.g. a public and a private one) |
@@ -231,7 +231,7 @@ https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-regional
 3) Make sure you have setup new or modified existing routes to use [httpApi event](https://serverless.com/framework/docs/providers/aws/events/http-api) in your serverless.yml file.
 4) Make the following changes to the `customDomain` properties in the serverless.yml confg:
     ```yaml
-    endpointType: regional
+    endpointType: REGIONAL
     apiType: http
     allowPathMatching: true # Only for one deploy
     ```

--- a/src/domain-config.ts
+++ b/src/domain-config.ts
@@ -67,7 +67,7 @@ class DomainConfig {
         const endpointTypeWithDefault = config.endpointType || Globals.endpointTypes.edge;
         const endpointTypeToUse = Globals.endpointTypes[endpointTypeWithDefault.toLowerCase()];
         if (!endpointTypeToUse) {
-            throw new Error(`${endpointTypeWithDefault} is not supported endpointType, use edge or regional.`);
+            throw new Error(`${endpointTypeWithDefault} is not supported endpointType, use EDGE or REGIONAL.`);
         }
         this.endpointType = endpointTypeToUse;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,13 +146,13 @@ class ServerlessCustomDomain {
             } else if (domain.apiType === Globals.apiTypes.http) { // Validation for http apis
                 // HTTP Apis do not support edge domains
                 if (domain.endpointType === Globals.endpointTypes.edge) {
-                    throw Error(`'edge' endpointType is not compatible with HTTP APIs`);
+                    throw Error(`'EDGE' endpointType is not compatible with HTTP APIs`);
                 }
 
             } else if (domain.apiType === Globals.apiTypes.websocket) { // Validation for WebSocket apis
                 // Websocket Apis do not support edge domains
                 if (domain.endpointType === Globals.endpointTypes.edge) {
-                    throw Error(`'edge' endpointType is not compatible with WebSocket APIs`);
+                    throw Error(`'EDGE' endpointType is not compatible with WebSocket APIs`);
                 }
             }
         });

--- a/test/integration-tests/basic/apigateway-with-export/serverless.yml
+++ b/test/integration-tests/basic/apigateway-with-export/serverless.yml
@@ -5,7 +5,7 @@ provider:
   name: aws
   runtime: nodejs12.x
   region: us-west-2
-  endpointType: regional
+  endpointType: REGIONAL
   stage: test
 functions:
   helloWorld:
@@ -42,7 +42,7 @@ custom:
     domainName: ${env:PLUGIN_IDENTIFIER}-apigateway-with-export-${env:RANDOM_STRING}.${env:TEST_DOMAIN}
     autoDomain: true
     basePath: hello-world
-    endpointType: regional
+    endpointType: REGIONAL
     createRoute53Record: false
 
 package:

--- a/test/integration-tests/basic/http-api-multiple/serverless.yml
+++ b/test/integration-tests/basic/http-api-multiple/serverless.yml
@@ -23,12 +23,12 @@ custom:
     - http:
         domainName: ${env:PLUGIN_IDENTIFIER}-http-api-multi-${env:RANDOM_STRING}.${env:TEST_DOMAIN}
         basePath: ''
-        endpointType: 'regional'
+        endpointType: REGIONAL
         autoDomain: true
     - http:
         domainName: ${env:PLUGIN_IDENTIFIER}-http-api-milti2-${env:RANDOM_STRING}.${env:TEST_DOMAIN}
         basePath: ''
-        endpointType: 'regional'
+        endpointType: REGIONAL
         autoDomain: true
 
 package:

--- a/test/integration-tests/deploy/http-api/serverless.yml
+++ b/test/integration-tests/deploy/http-api/serverless.yml
@@ -16,7 +16,7 @@ plugins:
 custom:
   customDomain:
     domainName: ${env:PLUGIN_IDENTIFIER}-http-api-${env:RANDOM_STRING}.${env:TEST_DOMAIN}
-    endpointType: regional
+    endpointType: REGIONAL
     apiType: http
 
 package:

--- a/test/integration-tests/deploy/regional-basepath/serverless.yml
+++ b/test/integration-tests/deploy/regional-basepath/serverless.yml
@@ -4,7 +4,7 @@ provider:
   name: aws
   runtime: nodejs12.x
   region: us-west-2
-  endpointType: regional
+  endpointType: REGIONAL
   stage: test
 functions:
   helloWorld:
@@ -20,7 +20,7 @@ custom:
   customDomain:
     domainName: ${env:PLUGIN_IDENTIFIER}-regional-basepath-${env:RANDOM_STRING}.${env:TEST_DOMAIN}
     basePath: 'api'
-    endpointType: regional
+    endpointType: REGIONAL
 
 package:
   patterns:

--- a/test/integration-tests/deploy/regional-stage-basepath/serverless.yml
+++ b/test/integration-tests/deploy/regional-stage-basepath/serverless.yml
@@ -4,7 +4,7 @@ provider:
   name: aws
   runtime: nodejs12.x
   region: us-west-2
-  endpointType: regional
+  endpointType: REGIONAL
   stage: test
 functions:
   helloWorld:
@@ -21,7 +21,7 @@ custom:
     domainName: ${env:PLUGIN_IDENTIFIER}-regional-stage-basepath-${env:RANDOM_STRING}.${env:TEST_DOMAIN}
     stage: test
     basePath: ''
-    endpointType: regional
+    endpointType: REGIONAL
 
 package:
   patterns:

--- a/test/integration-tests/deploy/regional-tls-1-0/serverless.yml
+++ b/test/integration-tests/deploy/regional-tls-1-0/serverless.yml
@@ -5,7 +5,7 @@ provider:
   runtime: nodejs12.x
   region: us-west-2
   stage: test
-  endpointType: regional
+  endpointType: REGIONAL
 
 functions:
   helloWorld:
@@ -21,7 +21,7 @@ custom:
   customDomain:
     domainName: ${env:PLUGIN_IDENTIFIER}-regional-tls-1-0-${env:RANDOM_STRING}.${env:TEST_DOMAIN}
     securityPolicy: tls_1_0
-    endpointType: regional
+    endpointType: REGIONAL
 
 package:
   patterns:

--- a/test/integration-tests/deploy/route-53-latency-routing/serverless.yml
+++ b/test/integration-tests/deploy/route-53-latency-routing/serverless.yml
@@ -3,7 +3,7 @@ provider:
   name: aws
   runtime: nodejs12.x
   region: us-west-2
-  endpointType: regional
+  endpointType: REGIONAL
   stage: test
 functions:
   helloWorld:
@@ -18,7 +18,7 @@ plugins:
 custom:
   customDomain:
     domainName: ${env:PLUGIN_IDENTIFIER}-route-53-latency-routing-${env:RANDOM_STRING}.${env:TEST_DOMAIN}
-    endpointType: regional
+    endpointType: REGIONAL
     route53Params:
       routingPolicy: latency
 

--- a/test/integration-tests/deploy/route-53-weighted-routing/serverless.yml
+++ b/test/integration-tests/deploy/route-53-weighted-routing/serverless.yml
@@ -3,7 +3,7 @@ provider:
   name: aws
   runtime: nodejs12.x
   region: us-west-2
-  endpointType: regional
+  endpointType: REGIONAL
   stage: test
 functions:
   helloWorld:
@@ -18,7 +18,7 @@ plugins:
 custom:
   customDomain:
     domainName: ${env:PLUGIN_IDENTIFIER}-route-53-weighted-routing-${env:RANDOM_STRING}.${env:TEST_DOMAIN}
-    endpointType: regional
+    endpointType: REGIONAL
     route53Params:
       routingPolicy: weighted
       weight: 100

--- a/test/integration-tests/deploy/web-socket/serverless.yml
+++ b/test/integration-tests/deploy/web-socket/serverless.yml
@@ -17,7 +17,7 @@ custom:
     websocket:
       domainName: ${env:PLUGIN_IDENTIFIER}-web-socket-${env:RANDOM_STRING}.${env:TEST_DOMAIN}
       basePath: ''
-      endpointType: 'regional'
+      endpointType: REGIONAL
 
 package:
   patterns:

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -170,7 +170,7 @@ describe("Custom Domain Plugin", () => {
                 plugin.initializeVariables();
             } catch (err) {
                 errored = true;
-                expect(err.message).to.equal("notSupported is not supported endpointType, use edge or regional.");
+                expect(err.message).to.equal("notSupported is not supported endpointType, use EDGE or REGIONAL.");
             }
             expect(errored).to.equal(true);
         });
@@ -226,7 +226,7 @@ describe("Custom Domain Plugin", () => {
             const plugin = constructPlugin({
                 basePath: "test_basepath",
                 domainName: "test_domain",
-                endpointType: "edge",
+                endpointType: "EDGE",
             });
             plugin.initializeVariables();
             plugin.initAWSResources();
@@ -253,7 +253,7 @@ describe("Custom Domain Plugin", () => {
             const plugin = constructPlugin({
                 basePath: "test_basepath",
                 domainName: "test_domain",
-                endpointType: "regional",
+                endpointType: "REGIONAL",
                 securityPolicy: "tls_1_0",
             });
             plugin.initializeVariables();
@@ -281,7 +281,7 @@ describe("Custom Domain Plugin", () => {
             const plugin = constructPlugin({
                 basePath: "test_basepath",
                 domainName: "test_domain",
-                endpointType: "regional",
+                endpointType: "REGIONAL",
             });
             plugin.initializeVariables();
             plugin.initAWSResources();
@@ -309,7 +309,7 @@ describe("Custom Domain Plugin", () => {
                 apiType: "http",
                 basePath: "test_basepath",
                 domainName: "test_domain",
-                endpointType: "regional",
+                endpointType: "REGIONAL",
             });
             plugin.initializeVariables();
             plugin.initAWSResources();
@@ -368,7 +368,7 @@ describe("Custom Domain Plugin", () => {
                 apiType: "http",
                 basePath: "test_basepath",
                 domainName: "test_domain",
-                endpointType: "regional",
+                endpointType: "REGIONAL",
             });
             plugin.initializeVariables();
             plugin.initAWSResources();
@@ -647,7 +647,7 @@ describe("Custom Domain Plugin", () => {
                 callback(null, {DomainName: "foo", DomainNameConfigurations: [{SecurityPolicy: "TLS_1_2"}]});
             });
 
-            const plugin = constructPlugin({domainName: "test_domain", apiType: "http", endpointType: "regional"});
+            const plugin = constructPlugin({domainName: "test_domain", apiType: "http", endpointType: "REGIONAL"});
             plugin.initializeVariables();
             plugin.initAWSResources();
 
@@ -981,7 +981,7 @@ describe("Custom Domain Plugin", () => {
                 apiType: "http",
                 basePath: "test_basepath",
                 domainName: "test_domain",
-                endpointType: "regional",
+                endpointType: "REGIONAL",
             });
             plugin.initializeVariables();
             plugin.initAWSResources();
@@ -1036,7 +1036,7 @@ describe("Custom Domain Plugin", () => {
                 apiType: "websocket",
                 basePath: "test_basepath",
                 domainName: "test_domain",
-                endpointType: "regional",
+                endpointType: "REGIONAL",
             });
             plugin.initializeVariables();
             plugin.initAWSResources();
@@ -2159,7 +2159,7 @@ describe("Custom Domain Plugin", () => {
             const plugin = constructPlugin({
                 basePath: "test_basepath",
                 domainName: "test_domain",
-                endpointType: "regional",
+                endpointType: "REGIONAL",
                 route53Params: {
                     routingPolicy: 'latency'
                 }
@@ -2237,7 +2237,7 @@ describe("Custom Domain Plugin", () => {
             const plugin = constructPlugin({
                 basePath: "test_basepath",
                 domainName: "test_domain",
-                endpointType: "regional",
+                endpointType: "REGIONAL",
                 route53Params: {
                     routingPolicy: 'weighted',
                     weight: 100,
@@ -2319,7 +2319,7 @@ describe("Custom Domain Plugin", () => {
             const plugin = constructPlugin({
                 basePath: "test_basepath",
                 domainName: "test_domain",
-                endpointType: "regional",
+                endpointType: "REGIONAL",
                 route53Params: {
                     routingPolicy: 'latency',
                     weight: 100,
@@ -2398,7 +2398,7 @@ describe("Custom Domain Plugin", () => {
             const plugin = constructPlugin({
                 basePath: "test_basepath",
                 domainName: "test_domain",
-                endpointType: "regional",
+                endpointType: "REGIONAL",
                 route53Params: {
                     setIdentifier: "test_identifier",
                     weight: 100,


### PR DESCRIPTION
This pull request changes the case of the `endpointType` value, while case [doesn't matter](https://github.com/serverless/serverless/blob/38fe02ef81ac60967852dd4489e5f6dfec3ce3b3/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js#L18-L31) this makes it consistent with the use elsewhere in Serverless and AWS.