### PR TITLE
Alt name

### DIFF
--- a/src/aws/acm-wrapper.ts
+++ b/src/aws/acm-wrapper.ts
@@ -53,9 +53,10 @@ class ACMWrapper {
      * * Gets Certificate ARN that most closely matches Cert ARN and not expired
      */
     private async getCertArnByCertName(certificates, certName): Promise<string> {
-        // note: we only check DomainName, but a future enhancement could
-        // be to also check SubjectAlternativeNames
-        const matches = certificates.filter((certificate) => (certificate.DomainName === certName));
+        const matches = certificates.filter((cert) => (
+          cert.DomainName === certName
+            || (cert.SubjectAlternativeNameSummaries || []).includes(certName)
+        ));
         for (const certificate of matches) {
             const certificateArn = certificate.CertificateArn;
             const details = await throttledCall(


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes (no ticket)

**Description of Issue Fixed**
Only primary AWS cert names were searched, secondary/alt names were not used at all.

**Changes proposed in this pull request**:

* also search secondary/alt names, but prefer a primary name match if available

You can easily test my changes with the tarball release I made in my fork: https://github.com/tomsaleeba/serverless-domain-manager/releases/tag/6.2.0-alt-name-2.
```
yarn add -D https://github.com/tomsaleeba/serverless-domain-manager/releases/download/6.2.0-alt-name-2/serverless-domain-manager-6.2.0.tgz
```

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->