### PR TITLE
Search SubjectAlternativeNames when finding cert

### DIFF
--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -22,10 +22,6 @@ const certTestData = {
             DomainName: "test_domain",
         },
         {
-            CertificateArn: "expired_cert_name",
-            DomainName: "cert_name",
-        },
-        {
             CertificateArn: "test_given_cert_name",
             DomainName: "cert_name",
         },
@@ -709,30 +705,6 @@ describe("Custom Domain Plugin", () => {
 
         it("Get a given certificate name", async () => {
             AWS.mock("ACM", "listCertificates", certTestData);
-            AWS.mock("ACM", "describeCertificate", (params, callback) => {
-                const fifteenDaysAsMs = 15 * 24 * 60 * 60 * 1000;
-                const fifteenDaysInFuture = new Date(Date.now() + fifteenDaysAsMs);
-                const fifteenDaysInPast = new Date(Date.now() - fifteenDaysAsMs);
-                if (params.CertificateArn === "expired_cert_name") {
-                    callback(null, {
-                        Certificate: {
-                            CertificateArn: "doesnt_matter_wont_be_used",
-                            NotAfter: fifteenDaysInPast,
-                        }
-                    });
-                    return;
-                }
-                if (params.CertificateArn === "test_given_cert_name") {
-                    callback(null, {
-                        Certificate: {
-                            CertificateArn: params.CertificateArn,
-                            NotAfter: fifteenDaysInFuture,
-                        }
-                    });
-                    return;
-                }
-                throw new Error("Programmer error: didn't add new test mock data");
-            });
 
             const plugin = constructPlugin({certificateName: "cert_name"});
             plugin.initializeVariables();
@@ -742,6 +714,91 @@ describe("Custom Domain Plugin", () => {
             const result = await acm.getCertArn(dc);
 
             expect(result).to.equal("test_given_cert_name");
+        });
+
+        it("Get a given certificate by alt name with exact match", async () => {
+            AWS.mock("ACM", "listCertificates", {
+                CertificateSummaryList: [
+                    {
+                        CertificateArn: "test_nomatch",
+                        DomainName: "dontmatch.com",
+                    },
+                    {
+                        CertificateArn: "test_arn",
+                        DomainName: "test.com",
+                        SubjectAlternativeNameSummaries: [
+                          "example.com",
+                        ],
+                    },
+                ],
+            });
+
+            const options = {
+                domainName: "example.com",
+                endpointType: "REGIONAL",
+            };
+            const plugin = constructPlugin(options);
+            plugin.initializeVariables();
+
+            const dc: DomainConfig = new DomainConfig(plugin.serverless.service.custom.customDomain);
+            const acm = new ACMWrapper(dc.endpointType);
+            const result = await acm.getCertArn(dc);
+
+            expect(result).to.equal("test_arn");
+        });
+
+        it("Get a given certificate by alt name with subdomain", async () => {
+            AWS.mock("ACM", "listCertificates", {
+                CertificateSummaryList: [
+                    {
+                        CertificateArn: "test_arn",
+                        DomainName: "test.com",
+                        SubjectAlternativeNameSummaries: [
+                          "example.com",
+                        ],
+                    },
+                ],
+            });
+
+            const options = {
+                domainName: "sub.example.com",
+                endpointType: "REGIONAL",
+            };
+            const plugin = constructPlugin(options);
+            plugin.initializeVariables();
+
+            const dc: DomainConfig = new DomainConfig(plugin.serverless.service.custom.customDomain);
+            const acm = new ACMWrapper(dc.endpointType);
+            const result = await acm.getCertArn(dc);
+
+            expect(result).to.equal("test_arn");
+        });
+
+        it("Get a given certificate by alt name with wildcard", async () => {
+            AWS.mock("ACM", "listCertificates", {
+                CertificateSummaryList: [
+                    {
+                        CertificateArn: "test_arn",
+                        DomainName: "test.com",
+                        SubjectAlternativeNameSummaries: [
+                          "*.example.com",
+                        ],
+                    },
+                ],
+            });
+
+            const options = {
+                domainName: "sub.example.com",
+                endpointType: "REGIONAL",
+            };
+            const plugin = constructPlugin(options);
+            plugin.initializeVariables();
+
+            const dc: DomainConfig = new DomainConfig(plugin.serverless.service.custom.customDomain);
+            const acm = new ACMWrapper(dc.endpointType);
+            const result = await acm.getCertArn(dc);
+
+            expect(result).to.equal("test_arn");
         });
 
         it("Create a domain name", async () => {


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes (no ticket)

**Description of Issue Fixed**
- cert alt names are not searched

**Changes proposed in this pull request**:

* search alt names when "searching by domain"
* remove code around expired certs as it's no longer needed (we filter the statuses instead)

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->
