### PR TITLE
Check base path and not stage for '/' in rest API creation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -193,7 +193,7 @@ class ServerlessCustomDomain {
         // multi-level base path mapping is supported by Gateway V2
         // https://github.com/amplify-education/serverless-domain-manager/issues/558
         // https://aws.amazon.com/blogs/compute/using-multiple-segments-in-amazon-api-gateway-base-path-mapping/
-        if (domain.baseStage.includes("/")) {
+        if (domain.basePath.includes("/")) {
             return this.apiGatewayV2Wrapper;
         }
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #558 

**Description of Issue Fixed**
Hi there, I've encountered the same issue that was described in #558 , however the update to 6.4.3 doesn't seem to have fixed this. I think the check for a '/' in the baseStage parameter should instead be checking the 'basePath' parameter, when determining the API wrapper version to use.

**Changes proposed in this pull request**:

* Check basePath parameter for '/'
* Test case for the above

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->
