### PR TITLE
Fixed not getting all paginated results from AWS clients calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.1.2] - 2023-08-14
+
+### Fixed 
+- Fixed not getting all paginated results from AWS clients calls. Thank you @sromic ([592](https://github.com/amplify-education/serverless-domain-manager/pull/592))
+
 ## [7.1.1] - 2023-07-24
 
 ### Fixed 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "engines": {
     "node": ">=14"
   },

--- a/test/unit-tests/aws/acm-wrapper.test.ts
+++ b/test/unit-tests/aws/acm-wrapper.test.ts
@@ -60,29 +60,29 @@ describe("ACM Wrapper checks", () => {
         const actualResult = await acmWrapper.getCertArn(dc);
         expect(actualResult).to.equal(testCertificateArnByDomain);
     });
-    
-    it("getCertArn by domain name by getting all paginated certificates from AWS", async () => { 
+
+    it("getCertArn by domain name by getting all paginated certificates from AWS", async () => {
         const ACMCMock = mockClient(ACMClient);
         ACMCMock.on(ListCertificatesCommand)
-        .resolvesOnce({
-          CertificateSummaryList: [
-            {
-              CertificateArn: "test_domain_arn",
-              DomainName: "test_domain",
-              Status: "ISSUED",
-            },
-          ],
-          NextToken: 'NextToken',
-        })
-        .resolves({
-          CertificateSummaryList: [
-            {
-              CertificateArn: "test_domain_arn2",
-              DomainName: "test_domain2",
-              Status: "ISSUED",
-            },
-          ],
-        });
+            .resolvesOnce({
+                CertificateSummaryList: [
+                    {
+                        CertificateArn: "test_domain_arn",
+                        DomainName: "test_domain",
+                        Status: "ISSUED",
+                    },
+                ],
+                NextToken: 'NextToken',
+            })
+            .resolves({
+                CertificateSummaryList: [
+                    {
+                        CertificateArn: "test_domain_arn2",
+                        DomainName: "test_domain2",
+                        Status: "ISSUED",
+                    },
+                ],
+            });
 
         const acmWrapper = new ACMWrapper(null, Globals.endpointTypes.regional);
         const dc = new DomainConfig(getDomainConfig({

--- a/test/unit-tests/aws/api-gateway-v1-wrapper.test.ts
+++ b/test/unit-tests/aws/api-gateway-v1-wrapper.test.ts
@@ -361,30 +361,30 @@ describe("API Gateway V1 wrapper checks", () => {
 
             expect(commandCalls.length).to.equal(1);
         });
-        
+
         it("get all base path mappings", async () => {
             const APIGatewayCMock = mockClient(APIGatewayClient);
             APIGatewayCMock.on(GetBasePathMappingsCommand)
-              .resolvesOnce({
-                items: [
-                  {
-                    restApiId: "test_rest_api_id",
-                    basePath: "test",
-                    stage: "test"
-                  },
-                ],
-                position: "position",
-              })
-              .resolves({
-                items: [
-                  {
-                    restApiId: "test_rest_api_id2",
-                    basePath: "test2",
-                    stage: "test",
-                  },
-                ],
-              });
-      
+                .resolvesOnce({
+                    items: [
+                        {
+                            restApiId: "test_rest_api_id",
+                            basePath: "test",
+                            stage: "test"
+                        },
+                    ],
+                    position: "position",
+                })
+                .resolves({
+                    items: [
+                        {
+                            restApiId: "test_rest_api_id2",
+                            basePath: "test2",
+                            stage: "test",
+                        },
+                    ],
+                });
+
             const apiGatewayV1Wrapper = new APIGatewayV1Wrapper();
             const dc = new DomainConfig(getDomainConfig({
                 domainName: "test_domain"

--- a/test/unit-tests/aws/api-gateway-v2-wrapper.test.ts
+++ b/test/unit-tests/aws/api-gateway-v2-wrapper.test.ts
@@ -395,7 +395,7 @@ describe("API Gateway V2 wrapper checks", () => {
 
             expect(commandCalls.length).to.equal(1);
         });
-        
+
         it("get all base path mappings", async () => {
             const APIGatewayMock = mockClient(ApiGatewayV2Client);
             APIGatewayMock.on(GetApiMappingsCommand).resolvesOnce({
@@ -407,14 +407,14 @@ describe("API Gateway V2 wrapper checks", () => {
                 }],
                 NextToken: "NextToken"
             })
-            .resolves({
-                Items: [{
-                    ApiId: "test_rest_api_id2",
-                    ApiMappingKey: "test2",
-                    Stage: "test",
-                    ApiMappingId: "test_id2"
-                }]
-            });
+                .resolves({
+                    Items: [{
+                        ApiId: "test_rest_api_id2",
+                        ApiMappingKey: "test2",
+                        Stage: "test",
+                        ApiMappingId: "test_id2"
+                    }]
+                });
 
             const apiGatewayV2Wrapper = new APIGatewayV2Wrapper();
             const dc = new DomainConfig(getDomainConfig({

--- a/test/unit-tests/aws/cloud-formation-wrapper.test.ts
+++ b/test/unit-tests/aws/cloud-formation-wrapper.test.ts
@@ -5,8 +5,7 @@ import {mockClient} from "aws-sdk-client-mock";
 import {
     CloudFormationClient,
     DescribeStackResourceCommand, DescribeStacksCommand,
-    ListExportsCommand, ListExportsCommandOutput,
-    ResourceStatus, StackStatus
+    ListExportsCommand, ResourceStatus, StackStatus
 } from "@aws-sdk/client-cloudformation";
 
 describe("Cloud Formation wrapper checks", () => {
@@ -56,7 +55,7 @@ describe("Cloud Formation wrapper checks", () => {
         const commandCalls = CloudFormationMock.commandCalls(ListExportsCommand, expectedParams, true);
         expect(commandCalls.length).to.equal(1);
     });
-    
+
     it("findApiId for the rest api type via Fn::ImportValue paginated", async () => {
         const fnImportValue = "test-value";
         const CloudFormationMock = mockClient(CloudFormationClient);
@@ -67,12 +66,12 @@ describe("Cloud Formation wrapper checks", () => {
             ],
             NextToken: "NextToken"
         })
-        .resolves({
-            Exports: [
-                {Name: "test-name2", Value: "test-name2"},
-                {Name: "dummy-name2", Value: "dummy-value2"},
-            ]
-        });
+            .resolves({
+                Exports: [
+                    {Name: "test-name2", Value: "test-name2"},
+                    {Name: "dummy-name2", Value: "dummy-value2"},
+                ]
+            });
 
         const cloudFormationWrapper = new CloudFormationWrapper();
         Globals.serverless.service.provider.apiGateway.restApiId = {
@@ -297,7 +296,7 @@ describe("Cloud Formation wrapper checks", () => {
         const allCommandCalls = CloudFormationMock.commandCalls(DescribeStackResourceCommand);
         expect(allCommandCalls.length).to.equal(2);
     });
-    
+
     it("findApiId for the rest api type with paginated nested stacks", async () => {
         const physicalResourceId = "test_rest_api_id";
         const nestedStackName = "custom-stage-name-NestedStackTwo-U89W84TQIHJK";
@@ -335,16 +334,16 @@ describe("Cloud Formation wrapper checks", () => {
             ],
             NextToken: "NextToken"
         })
-        .resolves({
-            Stacks: [
-                {
-                    StackName: "custom-stage-name-NestedStackOne-U89W84TQ1235",
-                    RootId: "arn:aws:cloudformation:us-east-1:000000000000:stack/dummy-name2/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-                    CreationTime: null,
-                    StackStatus: StackStatus.CREATE_COMPLETE
-                }                
-            ],
-        });
+            .resolves({
+                Stacks: [
+                    {
+                        StackName: "custom-stage-name-NestedStackOne-U89W84TQ1235",
+                        RootId: "arn:aws:cloudformation:us-east-1:000000000000:stack/dummy-name2/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+                        CreationTime: null,
+                        StackStatus: StackStatus.CREATE_COMPLETE
+                    }
+                ],
+            });
 
         const actualResult = await new CloudFormationWrapper().findApiId(Globals.apiTypes.rest)
         expect(actualResult).to.equal(physicalResourceId);
@@ -359,7 +358,7 @@ describe("Cloud Formation wrapper checks", () => {
 
         const allCommandCalls = CloudFormationMock.commandCalls(DescribeStackResourceCommand);
         expect(allCommandCalls.length).to.equal(2);
-        
+
         const describeStacksCommandCalls = CloudFormationMock.commandCalls(DescribeStacksCommand);
         expect(describeStacksCommandCalls.length).to.equal(2);
     });

--- a/test/unit-tests/aws/route53-wrapper.test.ts
+++ b/test/unit-tests/aws/route53-wrapper.test.ts
@@ -70,7 +70,7 @@ describe("Route53 wrapper checks", () => {
         actualId = await new Route53Wrapper().getRoute53HostedZoneId(dc);
         expect(actualId).to.equal(dc.hostedZoneId);
     });
-    
+
     it("get route53 hosted zone id paginated", async () => {
         const testId = "test_host_id"
         const Route53Mock = mockClient(Route53Client);
@@ -91,51 +91,51 @@ describe("Route53 wrapper checks", () => {
                     Config: {PrivateZone: false},
                     Id: testId,
                     Name: "domain",
-                }                
-            ],
-            NextMarker: "NextMarker"
-        })
-        .resolvesOnce({
-            HostedZones: [
-                {
-                    CallerReference: "4",
-                    Config: {PrivateZone: false},
-                    Id: testId,
-                    Name: "test_domain2",
-                }, {
-                    CallerReference: "5",
-                    Config: {PrivateZone: false},
-                    Id: testId,
-                    Name: "dummy_test_domain2",
-                }, {
-                    CallerReference: "6",
-                    Config: {PrivateZone: false},
-                    Id: testId,
-                    Name: "domain2",
                 }
             ],
             NextMarker: "NextMarker"
         })
-        .resolves({
-            HostedZones: [
-                {
-                    CallerReference: "7",
-                    Config: {PrivateZone: false},
-                    Id: testId,
-                    Name: "test_domain3",
-                }, {
-                    CallerReference: "8",
-                    Config: {PrivateZone: false},
-                    Id: testId,
-                    Name: "dummy_test_domain3",
-                }, {
-                    CallerReference: "9",
-                    Config: {PrivateZone: false},
-                    Id: testId,
-                    Name: "domain3",
-                }
-            ]
-        });
+            .resolvesOnce({
+                HostedZones: [
+                    {
+                        CallerReference: "4",
+                        Config: {PrivateZone: false},
+                        Id: testId,
+                        Name: "test_domain2",
+                    }, {
+                        CallerReference: "5",
+                        Config: {PrivateZone: false},
+                        Id: testId,
+                        Name: "dummy_test_domain2",
+                    }, {
+                        CallerReference: "6",
+                        Config: {PrivateZone: false},
+                        Id: testId,
+                        Name: "domain2",
+                    }
+                ],
+                NextMarker: "NextMarker"
+            })
+            .resolves({
+                HostedZones: [
+                    {
+                        CallerReference: "7",
+                        Config: {PrivateZone: false},
+                        Id: testId,
+                        Name: "test_domain3",
+                    }, {
+                        CallerReference: "8",
+                        Config: {PrivateZone: false},
+                        Id: testId,
+                        Name: "dummy_test_domain3",
+                    }, {
+                        CallerReference: "9",
+                        Config: {PrivateZone: false},
+                        Id: testId,
+                        Name: "domain3",
+                    }
+                ]
+            });
 
         const dc = new DomainConfig(getDomainConfig({
             domainName: "test_domain"


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #587 

**Description of Issue Fixed**
The release of the https://github.com/amplify-education/serverless-domain-manager/pull/592

**Changes proposed in this pull request**:

* Added `getAWSPagedResults` function for the getting paget results
* Added `retryStrategy` for all AWS clients
* Updated unittests

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->
