### PR TITLE
AT-11223: Update ACM get certificate error for the Edge endpoint type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.3.6] - 2023-02-13
+
+### Changed
+- Updated ACM get certificate error message for the endpoint type `EDGE`. More info https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-edge-optimized-custom-domain-name.html
+
 ## [7.3.5] - 2023-02-06
 
 ### Fixed 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,8 @@ NOTE: Always test this process in a lower level staging or development environme
 * (1/17/2018) The `create_domain` command provided by this plugin does not currently update an existing Custom Domain's configuration. Instead, it only supports updating the Route 53 record pointing to the Custom Domain. For example, one must delete and recreate a Custom Domain to migrate it from regional to edge or vice versa, or to modify the certificate.
 * (8/22/2018) Creating a custom domain creates a CloudFront Distribution behind the scenes for fronting your API Gateway. This CloudFront Distribution is managed by AWS and cannot be viewed/managed by you. This is not a bug, but a quirk of how the Custom Domain feature works in API Gateway.
 * (2/12/2019) Users who upgraded from 2.x.x to version 3.0.4 (now unpublished) and then reverted back to 2.x.x will be unable to deploy because of a bug that will be fixed in 3.1.0. The workaround is to delete the basepath mapping manually, which will let them successfully revert back to 2.x.x.
-* (1/20/2022) Using `route53Profile` option requires having hosted zone for the domain in this profile and ACM certificate in the main profile (where functions are deployed).  
+* (1/20/2022) Using `route53Profile` option requires having hosted zone for the domain in this profile and ACM certificate in the main profile (where functions are deployed).
+* (2/13/2024) ACM certificate must exist in the `us-east-1` for the `EDGE` endpoint type. https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-edge-optimized-custom-domain-name.html
 
 # Responsible Disclosure
 If you have any security issue to report, contact project maintainers privately.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "7.3.5",
+  "version": "7.3.6",
   "engines": {
     "node": ">=14"
   },

--- a/src/aws/acm-wrapper.ts
+++ b/src/aws/acm-wrapper.ts
@@ -55,7 +55,12 @@ class ACMWrapper {
       throw Error(`Could not search certificates in Certificate Manager.\n${err.message}`);
     }
     if (certificateArn == null) {
-      throw Error(`Could not find an in-date certificate for '${certificateName}'.`);
+      let errorMessage = `Could not find an in-date certificate for '${certificateName}'.`;
+      if (domain.endpointType === Globals.endpointTypes.edge) {
+        errorMessage += ` The endpoint type '${Globals.endpointTypes.edge}' is used. ` +
+          `Make sure the needed ACM certificate exists in the '${Globals.defaultRegion}' region.`;
+      }
+      throw Error(errorMessage);
     }
     return certificateArn;
   }

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -76,7 +76,7 @@ export default class Globals {
       return await fromIni({ profile })();
     }
 
-    public static getRetryStrategy (attempts: number = 3, delay: number = 3000, backoff: number = 500) {
+    public static getRetryStrategy (attempts: number = 5, delay: number = 3000, backoff: number = 500) {
       return new ConfiguredRetryStrategy(
         attempts, // max attempts.
         // This example sets the backoff at 500ms plus 3s per attempt.

--- a/test/unit-tests/aws/acm-wrapper.test.ts
+++ b/test/unit-tests/aws/acm-wrapper.test.ts
@@ -170,4 +170,23 @@ describe("ACM Wrapper checks", () => {
     }
     expect(errored).to.equal(true);
   });
+
+  it("getCertArn failure for Edge", async () => {
+    const ACMCMock = mockClient(ACMClient);
+    ACMCMock.on(ListCertificatesCommand).resolves({ CertificateSummaryList: [] });
+
+    const acmWrapper = new ACMWrapper(null, Globals.endpointTypes.edge);
+    const dc = new DomainConfig(getDomainConfig({ domainName: "test_domain" }));
+
+    let errored = false;
+    try {
+      await acmWrapper.getCertArn(dc);
+    } catch (err) {
+      errored = true;
+      expect(err.message).to.contains(
+        `Make sure the needed ACM certificate exists in the '${Globals.defaultRegion}' region`
+      );
+    }
+    expect(errored).to.equal(true);
+  });
 });


### PR DESCRIPTION
https://amplify-education.atlassian.net/browse/AT-11223

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #509

**Description of Issue Fixed**
Updated ACM get certificate error message for the `EDGE` endpoint type

**Changes proposed in this pull request**:

* Error message update

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->
