### PR TITLE
Fix domain deleting when fail on not exist stack

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -408,6 +408,9 @@ class ServerlessCustomDomain {
             `Unable to remove base path mappings for '${domain.givenDomainName}':\n${err.message}`
           );
         }
+        if (domain.preserveExternalPathMappings) {
+          externalBasePathExists = true;
+        }
       }
 
       if (domain.autoDomain === true && !externalBasePathExists) {


### PR DESCRIPTION

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

**Description of Issue Fixed**
When stack not exists `findApiId()` fails on `getStack()` and then on `getNestedStack()`. Try block in `removeBasePathMappings()` do not set `externalBasePathExists` flag. As result domain that has other mappings are removed.

**Changes proposed in this pull request**:
This fix adds extra check to catch block of `removeBasePathMappings()` if option `preserveExternalPathMappings` is set in stack config (by setting this option user identify that domain should have another mappings) and set the flag `externalBasePathExists` that prevent removing domain.

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->
