### PR TITLE
chore: enable compatibility with Serverless Framework v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "serverless": "^2.60 || ^3.0.0 || ^4.0.0"
+        "serverless": ">=2.60"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-domain-manager",
-  "version": "7.3.6",
+  "version": "7.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-domain-manager",
-      "version": "7.3.6",
+      "version": "7.3.8",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-acm": "^3.525.0",
@@ -53,7 +53,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "serverless": "^2.60 || ^3.0.0"
+        "serverless": "^2.60 || ^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,6 @@
     "proxy-agent": "^6.4.0"
   },
   "peerDependencies": {
-    "serverless": "^2.60 || ^3.0.0"
+    "serverless": "^2.60 || ^3.0.0 || ^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -90,6 +90,6 @@
     "proxy-agent": "^6.4.0"
   },
   "peerDependencies": {
-    "serverless": "^2.60 || ^3.0.0 || ^4.0.0"
+    "serverless": ">=2.60"
   }
 }


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #632 

**Description of Issue Fixed**
Users can't use [serverless-domain-manager](https://github.com/amplify-education/serverless-domain-manager) with Serveerless Framework v4.

**Changes proposed in this pull request**:

Add `^4.0.0` to `peerDependencies`

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->
