### PR TITLE
Added random GUID to section name in logging output

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -56,7 +56,7 @@ export default class Logging {
       return;
     }
     if (Globals.v3Utils) {
-      Globals.serverless.addServiceOutputSection(Globals.pluginName, summaryList);
+      Globals.serverless.addServiceOutputSection(`${Globals.pluginName} - ${crypto.randomUUID()}`, summaryList);
     } else {
       Logging.cliLog("[Summary]", "Distribution Domain Name");
       summaryList.forEach((item) => {

--- a/test/unit-tests/logging.test.ts
+++ b/test/unit-tests/logging.test.ts
@@ -81,7 +81,7 @@ describe("Logging checks", () => {
       });
 
       Logging.printDomainSummary([dc]);
-      expect(consoleOutput[3]).to.equal("Serverless Domain Manager");
+      expect(consoleOutput[3]).to.match(/^(Serverless Domain Manager - )(\{?[A-Z0-9]{8}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{12}\}?)$/i);
     });
   });
 });


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #644 

**Description of Issue Fixed**
Unable to deploy multiple services using serverless compose when more than one service utilises the serverless domain manager plugin.

**Changes proposed in this pull request**:

* Appended a random GUID to the logging section name to make it unique
* Updated the logging unit tests to take the GUID into account.

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->
