### PR TITLE
feat: support updating security policy on existing custom domains

### DIFF
--- a/src/aws/api-gateway-v1-wrapper.ts
+++ b/src/aws/api-gateway-v1-wrapper.ts
@@ -20,7 +20,8 @@ import {
   GetDomainNamesCommand,
   GetDomainNamesCommandInput,
   GetDomainNamesCommandOutput,
-  UpdateBasePathMappingCommand
+  UpdateBasePathMappingCommand,
+  UpdateDomainNameCommand
 } from "@aws-sdk/client-api-gateway";
 import ApiGatewayMap = require("../models/api-gateway-map");
 import APIGatewayBase = require("../models/apigateway-base");
@@ -83,6 +84,46 @@ class APIGatewayV1Wrapper extends APIGatewayBase {
     } catch (err) {
       throw new Error(
         `V1 - Failed to create custom domain '${domain.givenDomainName}':\n${err.message}`
+      );
+    }
+  }
+
+  public async updateCustomDomain (domain: DomainConfig): Promise<DomainInfo> {
+    const domainNameId = await this.getDomainNameIdForPrivateDomain(domain);
+    const patchOperations: any[] = [];
+
+    if (domain.securityPolicy) {
+      patchOperations.push({
+        op: "replace",
+        path: "/securityPolicy",
+        value: domain.securityPolicy
+      });
+    }
+
+    if (patchOperations.length === 0) {
+      if (domain.domainInfo) {
+        return domain.domainInfo;
+      }
+      const fetchedInfo = await this.getCustomDomain(domain, true);
+      if (!fetchedInfo) {
+        throw new Error(`Unable to fetch domain info for '${domain.givenDomainName}'`);
+      }
+      return fetchedInfo;
+    }
+
+    try {
+      const domainInfo: GetDomainNameCommandOutput = await this.apiGateway.send(
+        new UpdateDomainNameCommand({
+          domainName: domain.givenDomainName,
+          patchOperations,
+          ...(domainNameId && { domainNameId })
+        })
+      );
+      Logging.logInfo(`V1 - Updated security policy for '${domain.givenDomainName}'`);
+      return new DomainInfo(domainInfo);
+    } catch (err) {
+      throw new Error(
+        `V1 - Failed to update custom domain '${domain.givenDomainName}':\n${(err as Error).message}`
       );
     }
   }

--- a/src/aws/api-gateway-v2-wrapper.ts
+++ b/src/aws/api-gateway-v2-wrapper.ts
@@ -22,7 +22,8 @@ import {
   GetDomainNamesCommand,
   GetDomainNamesCommandInput,
   GetDomainNamesCommandOutput,
-  UpdateApiMappingCommand
+  UpdateApiMappingCommand,
+  UpdateDomainNameCommand
 } from "@aws-sdk/client-apigatewayv2";
 import Logging from "../logging";
 import { getAWSPagedResults } from "../utils";
@@ -111,6 +112,45 @@ class APIGatewayV2Wrapper extends APIGatewayBase {
         );
       }
       Logging.logInfo(`V2 - '${domain.givenDomainName}' does not exist.`);
+    }
+  }
+
+  public async updateCustomDomain (domain: DomainConfig): Promise<DomainInfo> {
+    try {
+      const domainNameId = await this.getDomainNameIdForPrivateDomain(domain);
+
+      // Use cached domain info if available, otherwise fetch
+      let currentDomain = domain.domainInfo;
+      if (!currentDomain) {
+        currentDomain = await this.getCustomDomain(domain, false);
+      }
+      if (!currentDomain) {
+        throw new Error(`Unable to fetch current domain info for '${domain.givenDomainName}'`);
+      }
+
+      // Build updated DomainNameConfigurations with new security policy
+      const currentConfigs = ((currentDomain as any).DomainNameConfigurations || []);
+      const domainNameConfigurations = currentConfigs.map((config: any) => ({
+        CertificateArn: config.CertificateArn,
+        EndpointType: config.EndpointType,
+        SecurityPolicy: domain.securityPolicy || config.SecurityPolicy
+      }));
+
+      const params: any = {
+        DomainName: domain.givenDomainName,
+        DomainNameConfigurations: domainNameConfigurations,
+        ...(domainNameId && { DomainNameId: domainNameId })
+      };
+
+      const domainInfo: GetDomainNameCommandOutput = await this.apiGateway.send(
+        new UpdateDomainNameCommand(params)
+      );
+      Logging.logInfo(`V2 - Updated security policy for '${domain.givenDomainName}'`);
+      return new DomainInfo(domainInfo);
+    } catch (err) {
+      throw new Error(
+        `V2 - Failed to update custom domain '${domain.givenDomainName}':\n${(err as Error).message}`
+      );
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -266,16 +266,14 @@ class ServerlessCustomDomain {
                  New domains may take up to 40 minutes to be initialized.`);
       } else {
         Logging.logInfo(`Custom domain '${domain.givenDomainName}' already exists.`);
+        Logging.logInfo(`Security policy value: '${domain.securityPolicy}'`);
         if (domain.securityPolicy) {
-          Logging.logInfo(`DEBUG: Updating security policy to '${domain.securityPolicy}'`);
           try {
             domain.domainInfo = await apiGateway.updateCustomDomain(domain);
-            Logging.logInfo(`DEBUG: Update completed successfully`);
+            Logging.logInfo(`Updated security policy for '${domain.givenDomainName}' to '${domain.securityPolicy}'`);
           } catch (err) {
             Logging.logWarning(`Unable to update security policy for '${domain.givenDomainName}': ${(err as Error).message}`);
           }
-        } else {
-          Logging.logInfo(`DEBUG: No security policy specified`);
         }
       }
       await route53.changeResourceRecordSet(ChangeAction.UPSERT, domain);

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,6 +264,13 @@ class ServerlessCustomDomain {
                  New domains may take up to 40 minutes to be initialized.`);
       } else {
         Logging.logInfo(`Custom domain '${domain.givenDomainName}' already exists.`);
+        if (domain.securityPolicy) {
+          try {
+            domain.domainInfo = await apiGateway.updateCustomDomain(domain);
+          } catch (err) {
+            Logging.logWarning(`Unable to update security policy for '${domain.givenDomainName}': ${(err as Error).message}`);
+          }
+        }
       }
       await route53.changeResourceRecordSet(ChangeAction.UPSERT, domain);
     } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -249,7 +249,9 @@ class ServerlessCustomDomain {
     const route53 = new Route53Wrapper(route53Creds, domain.route53Region);
     const acm = new ACMWrapper(Globals.credentials, domain.endpointType);
 
+    Logging.logInfo(`DEBUG: Getting domain '${domain.givenDomainName}' (apiType: ${domain.apiType}, securityPolicy: ${domain.securityPolicy})`);
     domain.domainInfo = await apiGateway.getCustomDomain(domain);
+    Logging.logInfo(`DEBUG: Domain info result: ${domain.domainInfo ? 'exists' : 'not found'}`);
 
     try {
       if (!domain.domainInfo) {
@@ -265,11 +267,15 @@ class ServerlessCustomDomain {
       } else {
         Logging.logInfo(`Custom domain '${domain.givenDomainName}' already exists.`);
         if (domain.securityPolicy) {
+          Logging.logInfo(`DEBUG: Updating security policy to '${domain.securityPolicy}'`);
           try {
             domain.domainInfo = await apiGateway.updateCustomDomain(domain);
+            Logging.logInfo(`DEBUG: Update completed successfully`);
           } catch (err) {
             Logging.logWarning(`Unable to update security policy for '${domain.givenDomainName}': ${(err as Error).message}`);
           }
+        } else {
+          Logging.logInfo(`DEBUG: No security policy specified`);
         }
       }
       await route53.changeResourceRecordSet(ChangeAction.UPSERT, domain);

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,7 @@ class ServerlessCustomDomain {
         const domainTypeConfig = domain[apiType];
         if (domainTypeConfig) {
           domainTypeConfig.apiType = apiType;
+          Logging.logInfo(`Initializing domain config for '${domainTypeConfig.domainName}' (securityPolicy from config: ${domainTypeConfig.securityPolicy})`);
           this.domains.push(new DomainConfig(domainTypeConfig));
           isTypeConfigFound = true;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -325,13 +325,16 @@ class ServerlessCustomDomain {
    * Lifecycle function to createDomain before deploy and add domain info to the CloudFormation stack's Outputs
    */
   public async createOrGetDomainForCfOutputs (): Promise<void> {
+    Logging.logInfo(`DEBUG: createOrGetDomainForCfOutputs called, total domains: ${this.domains.length}`);
     await Promise.all(this.domains.map(async (domain) => {
+      Logging.logInfo(`DEBUG: Processing domain '${domain.givenDomainName}' (autoDomain: ${domain.autoDomain})`);
       if (domain.autoDomain) {
         Logging.logInfo("Creating domain name before deploy.");
         await this.createDomain(domain);
       }
 
       const apiGateway = this.getApiGateway(domain);
+      Logging.logInfo(`DEBUG: Getting domain info for '${domain.givenDomainName}' before polling`);
       domain.domainInfo = await apiGateway.getCustomDomain(domain);
 
       if (domain.autoDomain) {

--- a/src/models/apigateway-base.ts
+++ b/src/models/apigateway-base.ts
@@ -11,6 +11,8 @@ abstract class APIGatewayBase {
 
     abstract getCustomDomain(domain: DomainConfig, silent?: boolean): Promise<DomainInfo>;
 
+    abstract updateCustomDomain(domain: DomainConfig): Promise<DomainInfo>;
+
     abstract deleteCustomDomain(domain: DomainConfig): Promise<void>;
 
     abstract createBasePathMapping(domain: DomainConfig): Promise<void>;


### PR DESCRIPTION
- Add updateCustomDomain method to both V1 and V2 API Gateway wrappers
- Update createDomain to call updateCustomDomain when domain exists and securityPolicy is specified
- V1: Use PATCH operations to update security policy
- V2: Rebuild DomainNameConfigurations with updated security policy
- V2: Optimize to use cached domain info when available, reducing unnecessary API calls
- Add abstract updateCustomDomain method to base class for type safety

Fixes #516: Custom domains now properly update security policies when deploying to existing domains

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

**Description of Issue Fixed**


**Changes proposed in this pull request**:

* Change 1
* Change 2

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->
