### PR TITLE
feat: add `optional` flag to `serverless` peer dependency (#672)

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,5 +92,10 @@
   },
   "peerDependencies": {
     "serverless": ">=3"
+  },
+  "peerDependenciesMeta": {
+    "serverless": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #672

**Description of Issue Fixed**

`serverless-domain-manager` declares `serverless` as a `peerDependency`. Under npm 7+, missing peers are auto-installed by default, so the real `serverless` package gets pulled in even when a compatible framework is already provided another way.

**Changes proposed in this pull request**:

Mark the peer dependency as optional

```json
"peerDependenciesMeta": {
  "serverless": {
    "optional": true
  }
}
```

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->
