### PR TITLE
feat: remove `serverless` peer dependency (#672)

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,8 +89,5 @@
   "overrides": {
     "fast-xml-parser": "5.5.9",
     "diff": "8.0.3"
-  },
-  "peerDependencies": {
-    "serverless": ">=3"
   }
 }


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #672

**Description of Issue Fixed**

`serverless-domain-manager` declares `serverless` as a `peerDependency`. Under npm 7+, missing peers are auto-installed by default, so the real `serverless` package gets pulled in even when a compatible framework is already provided another way.

**Changes proposed in this pull request**:

`serverless` peer dependency is removed.

<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->
