### PR TITLE
chore: bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: github-hosted-static-ip
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Install and test
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
@@ -33,7 +33,7 @@ jobs:
 
       - name: Extract version
         id: extract_version
-        uses: Saionaro/extract-package-version@v1.3.0
+        uses: Saionaro/extract-package-version@v1.4.0
 
       - name: Get latest tag
         id: get_latest_tag
@@ -57,7 +57,7 @@ jobs:
 
       - name: Create release
         if: env.VERSION_CHANGED == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: 'v${{ steps.extract_version.outputs.version }}'
           generate_release_notes: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
       matrix:
         node-version: [ 18.x, 20.x, 22.x, 24.x ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'


### PR DESCRIPTION
## Summary

Bumps GitHub Actions to their latest pinned versions as part of the GitHub Actions consolidation effort across the org.

## Changed files

- `.github/workflows/publish.yml`
- `.github/workflows/test.yml`

## Version changes

| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | `v4` | `v6` |
| `actions/setup-node` | `v4` | `v6` |
| `Saionaro/extract-package-version` | `v1.3.0` | `v1.4.0` |
| `softprops/action-gh-release` | `v2` | `v3` |

No logic changes — only action ref updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
