### PR TITLE
Release 10.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [10.2.0] - 2026-06-09
+
+### Changed
+- Marked `serverless` peer dependency as optional to stop the forced auto-install when a compatible framework (e.g. `osls`) is already provided. Thank you @nolde ([673](https://github.com/amplify-education/serverless-domain-manager/pull/673))
+- Bumped GitHub Actions to latest versions ([675](https://github.com/amplify-education/serverless-domain-manager/pull/675))
+
 ## [10.1.0] - 2026-03-31
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-domain-manager",
-  "version": "10.1.0",
+  "version": "10.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-domain-manager",
-      "version": "10.1.0",
+      "version": "10.2.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-acm": "^3.1016.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "10.1.0",
+  "version": "10.2.0",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
**Changes proposed in this pull request**:

Cut release 10.2.0 — minor bump.

### Changed
- Marked `serverless` peer dependency as optional to stop the forced auto-install when a compatible framework (e.g. `osls`) is already provided. Thank you @nolde ([#673](https://github.com/amplify-education/serverless-domain-manager/pull/673), fixes [#672](https://github.com/amplify-education/serverless-domain-manager/issues/672))
- Bumped GitHub Actions to latest versions ([#675](https://github.com/amplify-education/serverless-domain-manager/pull/675))

🤖 Generated with [Claude Code](https://claude.com/claude-code)