### PR TITLE
fix: widen osls peer dependency range to >=3

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "diff": "8.0.3"
   },
   "peerDependencies": {
-    "osls": ">=4",
+    "osls": ">=3",
     "serverless": ">=3"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## What

Change the `osls` peer dependency range from `>=4` to `>=3`.

## Why

Follow-up to the review comment on #679, which flagged that `osls: ">=4"` would affect projects on osls v3 and asked whether the goal was to support **both** osls 3 and 4.

The plugin already supports both at runtime. It detects osls v4 via `provider.getAwsSdkV3Config()` (`Globals.hasSdkV3Config`) and falls back to the legacy `getCredentials()` / `sdk.config` surface when that's absent — the same path used for **serverless v3**. osls v3 goes through that identical fallback, so the code runs fine on it.

The `osls: ">=4"` range understated this actual compatibility:

- osls v3 users got peer-dependency warnings — and hard install failures under strict resolvers such as pnpm or `npm ci --strict-peer-deps` — even though the code works for them.
- It was internally inconsistent with the `serverless: ">=3"` peer range: osls is a maintained fork of serverless, and osls v3 (serverless v3 era) takes the exact same legacy fallback path.

`osls` remains an optional peer dependency, so this is **not a breaking change** — it just aligns the declared compatibility with what the code supports.