### PR TITLE
Release 10.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [10.3.1] - 2026-07-21
+
+### Fixed
+- Widened the `osls` optional peer dependency range to `>=3` so the declared compatibility matches the plugin's runtime behavior. Thank you @jbsilva ([681](https://github.com/amplify-education/serverless-domain-manager/pull/681))
+
 ## [10.3.0] - 2026-07-17
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "10.3.0",
+  "version": "10.3.1",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
## Release 10.3.1

Version bump and CHANGELOG update for the `10.3.1` release.

### Included
- Widened the `osls` optional peer dependency range to `>=3` so the declared compatibility matches the plugin's runtime behavior — when `getAwsSdkV3Config()` is absent it falls back to the legacy credential surface, so osls v3 works like serverless v3. Thank you @jbsilva ([#681](https://github.com/amplify-education/serverless-domain-manager/pull/681))

### Changes in this PR
- Bump `package.json` version `10.3.0` → `10.3.1`
- Add `[10.3.1]` CHANGELOG section

🤖 Generated with [Claude Code](https://claude.com/claude-code)